### PR TITLE
As a convenience for a test, write out the JOB_NAME as a param

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -170,6 +170,7 @@ func (o *options) Run() error {
 		log.Printf("Writing parameters to %s", o.writeParams)
 		var params []string
 
+		params = append(params, fmt.Sprintf("JOB_NAME=%q", o.jobSpec.Job))
 		params = append(params, fmt.Sprintf("NAMESPACE=%q", o.namespace))
 
 		if tagConfig := o.buildConfig.ReleaseTagConfiguration; tagConfig != nil {


### PR DESCRIPTION
Params are expected to be passed to other elements, and JOB_NAME is the
unique identifier for type within a PR.