### PR TITLE
Report build logs when a build fails

### DIFF
--- a/pkg/steps/build_client.go
+++ b/pkg/steps/build_client.go
@@ -1,0 +1,41 @@
+package steps
+
+import (
+	"io"
+
+	"k8s.io/client-go/rest"
+
+	buildapi "github.com/openshift/api/build/v1"
+	"github.com/openshift/client-go/build/clientset/versioned/scheme"
+	buildclientset "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
+)
+
+type BuildClient interface {
+	buildclientset.BuildInterface
+	Logs(name string, options *buildapi.BuildLogOptions) (io.ReadCloser, error)
+}
+
+type buildClient struct {
+	buildclientset.BuildInterface
+
+	client    rest.Interface
+	namespace string
+}
+
+func NewBuildClient(client buildclientset.BuildInterface, restClient rest.Interface, namespace string) BuildClient {
+	return &buildClient{
+		BuildInterface: client,
+		client:         restClient,
+		namespace:      namespace,
+	}
+}
+
+func (c *buildClient) Logs(name string, options *buildapi.BuildLogOptions) (io.ReadCloser, error) {
+	return c.client.Get().
+		Namespace(c.namespace).
+		Name(name).
+		Resource("builds").
+		SubResource("log").
+		VersionedParams(options, scheme.ParameterCodec).
+		Stream()
+}

--- a/pkg/steps/build_defaults.go
+++ b/pkg/steps/build_defaults.go
@@ -42,7 +42,8 @@ func FromConfig(config *api.ReleaseBuildConfiguration, jobSpec *JobSpec, cluster
 
 	jobNamespace := jobSpec.Namespace()
 
-	var buildClient buildclientset.BuildInterface
+	var buildClient BuildClient
+	var buildRESTClient rest.Interface
 	var imageStreamTagClient imageclientset.ImageStreamTagInterface
 	var imageStreamGetter imageclientset.ImageStreamsGetter
 	var imageStreamTagsGetter imageclientset.ImageStreamTagsGetter
@@ -58,7 +59,8 @@ func FromConfig(config *api.ReleaseBuildConfiguration, jobSpec *JobSpec, cluster
 		if err != nil {
 			return buildSteps, fmt.Errorf("could not get build client for cluster config: %v", err)
 		}
-		buildClient = buildGetter.Builds(jobNamespace)
+		buildRESTClient = buildGetter.RESTClient()
+		buildClient = NewBuildClient(buildGetter.Builds(jobNamespace), buildRESTClient, jobNamespace)
 
 		imageGetter, err := imageclientset.NewForConfig(clusterConfig)
 		if err != nil {

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -6,7 +6,6 @@ import (
 
 	buildapi "github.com/openshift/api/build/v1"
 	"github.com/openshift/ci-operator/pkg/api"
-	buildclientset "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 )
 
@@ -17,7 +16,7 @@ RUN ["/bin/bash", "-c", %s]`, PipelineImageStream, from, strconv.Quote(fmt.Sprin
 
 type pipelineImageCacheStep struct {
 	config      api.PipelineImageCacheStepConfiguration
-	buildClient buildclientset.BuildInterface
+	buildClient BuildClient
 	istClient   imageclientset.ImageStreamTagInterface
 	jobSpec     *JobSpec
 }
@@ -45,7 +44,7 @@ func (s *pipelineImageCacheStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(s.config.To)}
 }
 
-func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, buildClient buildclientset.BuildInterface, istClient imageclientset.ImageStreamTagInterface, jobSpec *JobSpec) api.Step {
+func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, buildClient BuildClient, istClient imageclientset.ImageStreamTagInterface, jobSpec *JobSpec) api.Step {
 	return &pipelineImageCacheStep{
 		config:      config,
 		buildClient: buildClient,

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -7,7 +7,6 @@ import (
 	buildapi "github.com/openshift/api/build/v1"
 	"github.com/openshift/api/image/docker10"
 	"github.com/openshift/ci-operator/pkg/api"
-	buildclientset "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	coreapi "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +14,7 @@ import (
 
 type projectDirectoryImageBuildStep struct {
 	config      api.ProjectDirectoryImageBuildStepConfiguration
-	buildClient buildclientset.BuildInterface
+	buildClient BuildClient
 	istClient   imageclientset.ImageStreamTagInterface
 	jobSpec     *JobSpec
 }
@@ -70,7 +69,7 @@ func (s *projectDirectoryImageBuildStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(s.config.To)}
 }
 
-func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, buildClient buildclientset.BuildInterface, istClient imageclientset.ImageStreamTagInterface, jobSpec *JobSpec) api.Step {
+func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, buildClient BuildClient, istClient imageclientset.ImageStreamTagInterface, jobSpec *JobSpec) api.Step {
 	return &projectDirectoryImageBuildStep{
 		config:      config,
 		buildClient: buildClient,

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	buildapi "github.com/openshift/api/build/v1"
-	buildclientset "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +18,7 @@ RUN echo $'[built]\nname = Built RPMs\nbaseurl = http://%s\ngpgcheck = 0\nenable
 
 type rpmImageInjectionStep struct {
 	config      api.RPMImageInjectionStepConfiguration
-	buildClient buildclientset.BuildInterface
+	buildClient BuildClient
 	routeClient routeclientset.RouteInterface
 	istClient   imageclientset.ImageStreamTagInterface
 	jobSpec     *JobSpec
@@ -58,7 +57,7 @@ func (s *rpmImageInjectionStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(s.config.To)}
 }
 
-func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, buildClient buildclientset.BuildInterface, routeClient routeclientset.RouteInterface, istClient imageclientset.ImageStreamTagInterface, jobSpec *JobSpec) api.Step {
+func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, buildClient BuildClient, routeClient routeclientset.RouteInterface, istClient imageclientset.ImageStreamTagInterface, jobSpec *JobSpec) api.Step {
 	return &rpmImageInjectionStep{
 		config:      config,
 		buildClient: buildClient,


### PR DESCRIPTION
@stevekuznetsov

```
2018/05/01 13:45:19 Setting up namespace for testing...
2018/05/01 13:45:19 Setting up pipeline imagestream for testing...
2018/05/01 13:45:19 Tagging release images into test-ci-op
2018/05/01 13:45:19 Tagging openshift/origin-v3.10:base into test-ci-op/pipeline:base-without-rpms
2018/05/01 13:45:19 Tagging ci/release-with-clonerefs:golang-1.9 into test-ci-op/pipeline:root
2018/05/01 13:45:20 Creating build for test-ci-op/pipeline:src
2018/05/01 13:45:20 Waiting for build src to finish
2018/05/01 13:45:25 Build test-ci-op/src failed, printing logs:
2018-05-01T17:45:21.306615978Z
2018-05-01T17:45:21.306682096Z Pulling image docker-registry.default.svc:5000/test-ci-op/pipeline@sha256:52acf0097a923c4c47ef0210d58460f209e973e23418777c32b355e7650f3a85 ...
2018-05-01T17:45:21.818425117Z Checking for Docker config file for PULL_DOCKERCFG_PATH in path /var/run/secrets/openshift.io/pull
2018-05-01T17:45:21.818578152Z Using Docker config file /var/run/secrets/openshift.io/pull/.dockercfg
2018-05-01T17:45:21.822325925Z --> FROM docker-registry.default.svc:5000/test-ci-op/pipeline@sha256:52acf0097a923c4c47ef0210d58460f209e973e23418777c32b355e7650f3a85 as 0
2018-05-01T17:45:22.074812968Z --> ENV "JOB_SPEC"="{\"type\":\"postsubmit\",\"job\":\"build_sample_image\",\"buildid\":\"f506c368-39d5-11e8-a837-0a58ac100475\",\"refs\":{\"org\":\"openshift\",\"repo\":\"image-registry\",\"base_ref\":\"master\",\"base_sha\":\"1c82db343d8a3ef7b08f5c0a21d2f5f4961e0121\"}}"
2018-05-01T17:45:22.074844456Z --> ENV GIT_COMMITTER_NAME=developer GIT_COMMITTER_EMAIL=developer@redhat.com
2018-05-01T17:45:22.074847533Z --> ENV REPO_OWNER=openshift REPO_NAME=image-registry PULL_REFS=master:1c82db343d8a3ef7b08f5c0a21d2f5f4961e0121
2018-05-01T17:45:22.074852634Z --> RUN umask 0002 && /usr/bin/clonerefs --src-root=/go --log=-
2018-05-01T17:45:22.198208159Z time="2018-05-01T17:45:22Z" level=fatal msg="Invalid options: no refs specified to clone"
2018-05-01T17:45:22.394291188Z error: build error: running '/bin/sh -c export "PULL_REFS=master:1c82db343d8a3ef7b08f5c0a21d2f5f4961e0121" "REPO_NAME=image-registry" "REPO_OWNER=openshift" "GIT_COMMITTER_EMAIL=developer@redhat.com" "GIT_COMMITTER_NAME=developer" "JOB_SPEC={\"type\":\"postsubmit\",\"job\":\"build_sample_image\",\"buildid\":\"f506c368-39d5-11e8-a837-0a58ac100475\",\"refs\":{\"org\":\"openshift\",\"repo\":\"image-registry\",\"base_ref\":\"master\",\"base_sha\":\"1c82db343d8a3ef7b08f5c0a21d2f5f4961e0121\"}}" "OPENSHIFT_BUILD_NAME=release-with-clonerefs-4" "OPENSHIFT_BUILD_NAMESPACE=ci" "VERSION=1.9" "GOARM=5" "GOPATH=/go" "GOROOT=/usr/local/go" "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin" "OPENSHIFT_BUILD_SOURCE=https://github.com/openshift/release.git" "OPENSHIFT_BUILD_REFERENCE=master" "OPENSHIFT_BUILD_COMMIT=b3d787a873f45eef7b4bdfd5dc5f01ab85de73ed" "JOB_SPEC={\"type\":\"postsubmit\",\"job\":\"build_sample_image\",\"buildid\":\"f506c368-39d5-11e8-a837-0a58ac100475\",\"refs\":{\"org\":\"openshift\",\"repo\":\"image-registry\",\"base_ref\":\"master\",\"base_sha\":\"1c82db343d8a3ef7b08f5c0a21d2f5f4961e0121\"}}" "GIT_COMMITTER_NAME=developer" "GIT_COMMITTER_EMAIL=developer@redhat.com" "REPO_OWNER=openshift" "REPO_NAME=image-registry" "PULL_REFS=master:1c82db343d8a3ef7b08f5c0a21d2f5f4961e0121"; cd "/go/src/github.com/openshift/origin" && umask 0002 && /usr/bin/clonerefs --src-root=/go --log=-' failed with exit code 1
error: failed to run steps: encountered errors running steps:
Operation cannot be fulfilled on imagestreamtags.image.openshift.io "pipeline": the object has been modified; please apply your changes to the latest version and try again
the build test-ci-op/src failed with status "Failed"
```