### PR TITLE
Create a deadman's switch on the namespace that guarantees it is cleaned up

### DIFF
--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -54,12 +54,15 @@ func Run(graph []*api.StepNode, dry bool) error {
 			close(done)
 
 			var aggregateErr error
-			if len(errors) > 0 {
+			if len(errors) == 1 {
+				return errors[0]
+			}
+			if len(errors) > 1 {
 				message := bytes.Buffer{}
 				for _, err := range errors {
-					message.WriteString(fmt.Sprintf("\n%s", err.Error()))
+					message.WriteString(fmt.Sprintf("\n  * %s", err.Error()))
 				}
-				aggregateErr = fmt.Errorf("encountered errors running steps:%s", message.String())
+				aggregateErr = fmt.Errorf("some steps failed:%s", message.String())
 			}
 			return aggregateErr
 		}


### PR DESCRIPTION
The `--delete-when-idle=DURATION` flag instructs the ci-operator to create
a pod that will delete the namespace if there are no running, pending, or
unknown restartPolicy=Never pods for longer than DURATION. This ensures
that the namespace is properly cleaned up when jobs exit. The created pod
has a hardcoded 12 hour limit before the namespace is torn down
automatically.