### PR TITLE
Match latest clonerefs changes

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -115,6 +115,10 @@ func loadClusterConfig() (*rest.Config, error) {
 }
 
 func (o *options) Run() error {
+	start := time.Now()
+	defer func() {
+		log.Printf("Ran for %s", time.Now().Sub(start).Truncate(time.Second))
+	}()
 	var is *imageapi.ImageStream
 	if !o.dry {
 		projectGetter, err := versioned.NewForConfig(o.clusterConfig)
@@ -137,7 +141,6 @@ func (o *options) Run() error {
 			}
 		}
 
-		log.Println("Setting up pipeline imagestream for testing ...")
 		imageGetter, err := imageclientset.NewForConfig(o.clusterConfig)
 		if err != nil {
 			return fmt.Errorf("could not get image client for cluster config: %v", err)
@@ -283,7 +286,7 @@ func (o *options) writeParameters(path string, is *imageapi.ImageStream) error {
 // createNamespaceCleanupPod creates a pod that deletes the job namespace if no other run-once pods are running
 // for more than idleCleanupDuration.
 func (o *options) createNamespaceCleanupPod() error {
-	log.Printf("Marking the namespace as slated for deletion after %s of idle time ...", o.idleCleanupDuration)
+	log.Printf("Namespace will be deleted after %s of idle time", o.idleCleanupDuration)
 	client, err := coreclientset.NewForConfig(o.clusterConfig)
 	if err != nil {
 		return fmt.Errorf("could not get image client for cluster config: %v", err)

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	appsapi "github.com/openshift/api/apps/v1"
 	routeapi "github.com/openshift/api/route/v1"
@@ -164,7 +163,8 @@ func (s *rpmServerStep) Run(dry bool) error {
 		}
 		fmt.Printf("%s\n", routeJSON)
 		return nil
-	} else if _, err := s.routeClient.Create(route); err != nil && !kerrors.IsAlreadyExists(err) {
+	}
+	if _, err := s.routeClient.Create(route); err != nil && !kerrors.IsAlreadyExists(err) {
 		return err
 	}
 	return waitForDeployment(s.deploymentClient, deploymentConfig.Name)
@@ -175,7 +175,6 @@ func (s *rpmServerStep) Done() (bool, error) {
 }
 
 func waitForDeployment(client appsclientset.DeploymentConfigInterface, name string) error {
-	log.Printf("Waiting for DeploymentConfig %s to finish", name)
 	for {
 		retry, err := waitForDeploymentOrTimeout(client, name)
 		if err != nil {


### PR DESCRIPTION
Picked up latest clonerefs changes.  Wait for namespace deletion before continuing.  Update log messages to be cleaner.  Print completion times.

```
2018/05/01 23:22:42 Creating namespace ci-op-b11b8c1ba3
2018/05/01 23:22:42 Waiting for namespace to finish terminating before creating another
2018/05/01 23:22:45 Waiting for namespace to finish terminating before creating another
2018/05/01 23:22:48 Waiting for namespace to finish terminating before creating another
2018/05/01 23:22:51 Waiting for namespace to finish terminating before creating another
2018/05/01 23:22:54 Waiting for namespace to finish terminating before creating another
2018/05/01 23:22:57 Waiting for namespace to finish terminating before creating another
2018/05/01 23:23:00 Waiting for namespace to finish terminating before creating another
2018/05/01 23:23:03 Namespace will be deleted after 2m0s of idle time
2018/05/01 23:23:04 Tagging release images into ci-op-b11b8c1ba3
2018/05/01 23:23:04 Tagging ci/release-with-clonerefs:golang-1.9 into ci-op-b11b8c1ba3/pipeline:root
2018/05/01 23:23:04 Tagging openshift/origin-v3.10:base into ci-op-b11b8c1ba3/pipeline:base-without-rpms
2018/05/01 23:23:04 Building ci-op-b11b8c1ba3/pipeline:src
2018/05/01 23:23:56 Build ci-op-b11b8c1ba3/src succeeded after 52s
2018/05/01 23:23:56 Building ci-op-b11b8c1ba3/pipeline:test-bin
2018/05/01 23:23:56 Building ci-op-b11b8c1ba3/pipeline:bin
2018/05/01 23:25:06 Build ci-op-b11b8c1ba3/bin succeeded after 1m10s
2018/05/01 23:25:06 Building ci-op-b11b8c1ba3/pipeline:rpms
2018/05/01 23:25:12 Build ci-op-b11b8c1ba3/test-bin succeeded after 1m16s
2018/05/01 23:26:47 Build ci-op-b11b8c1ba3/rpms succeeded after 1m40s
2018/05/01 23:27:01 Building ci-op-b11b8c1ba3/pipeline:base
2018/05/01 23:27:12 Build ci-op-b11b8c1ba3/base succeeded after 11s
2018/05/01 23:27:12 Building ci-op-b11b8c1ba3/pipeline:docker-registry
2018/05/01 23:27:40 Build ci-op-b11b8c1ba3/docker-registry succeeded after 28s
2018/05/01 23:27:40 Tagging ci-op-b11b8c1ba3/pipeline:docker-registry into ci-op-b11b8c1ba3/stable:docker-registry
2018/05/01 23:27:40 Writing parameters to /tmp/out
2018/05/01 23:27:40 Ran for 4m58s
```