### PR TITLE
Allow override of the default config via --override

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -69,6 +69,12 @@ type InputConfiguration struct {
 
 // ImageStreamTagReference identifies an ImageStreamTag
 type ImageStreamTagReference struct {
+	// Cluster is an optional cluster string (host, host:port, or
+	// scheme://host:port) to connect to for this image stream. The
+	// referenced cluster must support anonymous access to retrieve
+	// image streams, image stream tags, and image stream images in
+	// the provided namespace.
+	Cluster   string `json:"cluster"`
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
 	Tag       string `json:"tag"`
@@ -84,6 +90,13 @@ type ImageStreamTagReference struct {
 // (openshift/origin-control-plane:v3.9). The former works well for
 // central control, the latter for distributed control.
 type ReleaseTagConfiguration struct {
+	// Cluster is an optional cluster string (host, host:port, or
+	// scheme://host:port) to connect to for this image stream. The
+	// referenced cluster must support anonymous access to retrieve
+	// image streams, image stream tags, and image stream images in
+	// the provided namespace.
+	Cluster string `json:"cluster"`
+
 	// Namespace identifies the namespace from which
 	// all release artifacts not built in the current
 	// job are tagged from.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -11,12 +11,7 @@ package api
 //  - raw steps that can be used to create custom and
 //    fine-grained build flows
 type ReleaseBuildConfiguration struct {
-	// TestBaseImage is the image we base our pipeline
-	// image caches on. It should contain all build-time
-	// dependencies for the project. It is valid to set
-	// only the tag and allow for the other fields to be
-	// defaulted.
-	TestBaseImage *ImageStreamTagReference `json:"test_base_image,omitempty"`
+	InputConfiguration `json:",inline"`
 
 	// The following commands describe how binaries,
 	// test binaries and RPMs are built baseImage
@@ -33,28 +28,43 @@ type ReleaseBuildConfiguration struct {
 	// _output/local/releases/rpms/.
 	RpmBuildLocation string `json:"rpm_build_location,omitempty"`
 
-	// The following lists of base images describe
-	// which images are going to be necessary outside
-	// of the pipeline. RPM repositories will be
-	// injected into the baseRPMImages for downstream
-	// image builds that require built project RPMs.
-	BaseImages    []ImageStreamTagReference `json:"base_images,omitempty"`
-	BaseRPMImages []ImageStreamTagReference `json:"base_rpm_images,omitempty"`
-
 	// Images describes the images that are built
 	// baseImage the project as part of the release
 	// process
 	Images []ProjectDirectoryImageBuildStepConfiguration `json:"images,omitempty"`
 
-	// ReleaseTagConfiguration determines how the
-	// full release is assembled.
-	ReleaseTagConfiguration *ReleaseTagConfiguration `json:"tag_specification,omitempty"`
-
+	// Tests describes the tests to run inside of built images.
+	// The images launched as pods but have no explicit access to
+	// the cluster they are running on.
 	Tests []TestStepConfiguration `json:"tests,omitempty"`
 
 	// RawSteps are literal Steps that should be
 	// included in the final pipeline.
 	RawSteps []StepConfiguration `json:"raw_steps,omitempty"`
+}
+
+// InputConfiguration contains the set of image inputs
+// to a build and can be used as an override to the
+// canonical inputs by a local process.
+type InputConfiguration struct {
+	// The list of base images describe
+	// which images are going to be necessary outside
+	// of the pipeline. The key will be the alias that other
+	// steps use to refer to this image.
+	BaseImages map[string]ImageStreamTagReference `json:"base_images,omitempty"`
+	// BaseRPMImages is a list of the images and their aliases that will
+	// have RPM repositories injected into them for downstream
+	// image builds that require built project RPMs.
+	BaseRPMImages map[string]ImageStreamTagReference `json:"base_rpm_images,omitempty"`
+
+	// TestBaseImage is the image we should base our
+	// pipeline image caches on. It should contain all
+	// build-time dependencies for the project.
+	TestBaseImage *ImageStreamTagReference `json:"test_base_image,omitempty"`
+
+	// ReleaseTagConfiguration determines how the
+	// full release is assembled.
+	ReleaseTagConfiguration *ReleaseTagConfiguration `json:"tag_specification,omitempty"`
 }
 
 // ImageStreamTagReference identifies an ImageStreamTag

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestOverlay(t *testing.T) {
+	tests := []struct {
+		name      string
+		base      string
+		overlay   string
+		want      *ReleaseBuildConfiguration
+		wantInput *InputConfiguration
+	}{
+		{
+			name:      "empty",
+			base:      "{}",
+			overlay:   "{}",
+			want:      &ReleaseBuildConfiguration{},
+			wantInput: &InputConfiguration{},
+		},
+		{
+			name:    "empty",
+			base:    `{}`,
+			overlay: `{"base_images":{"test":{"name":"test-1"}}}`,
+			want: &ReleaseBuildConfiguration{
+				InputConfiguration: InputConfiguration{
+					BaseImages: map[string]ImageStreamTagReference{
+						"test": {Name: "test-1"},
+					},
+				},
+			},
+			wantInput: &InputConfiguration{
+				BaseImages: map[string]ImageStreamTagReference{
+					"test": {Name: "test-1"},
+				},
+			},
+		},
+		{
+			name:    "overwrite",
+			base:    `{"base_images":{"test":{"name":"test-0"}}}`,
+			overlay: `{"base_images":{"test":{"name":"test-1"}}}`,
+			want: &ReleaseBuildConfiguration{
+				InputConfiguration: InputConfiguration{
+					BaseImages: map[string]ImageStreamTagReference{
+						"test": {Name: "test-1"},
+					},
+				},
+			},
+			wantInput: &InputConfiguration{
+				BaseImages: map[string]ImageStreamTagReference{
+					"test": {Name: "test-1"},
+				},
+			},
+		},
+		{
+			name:    "map merge",
+			base:    `{"base_images":{"test-0":{"name":"test-0"}}}`,
+			overlay: `{"base_images":{"test-1":{"name":"test-1"}}}`,
+			want: &ReleaseBuildConfiguration{
+				InputConfiguration: InputConfiguration{
+					BaseImages: map[string]ImageStreamTagReference{
+						"test-0": {Name: "test-0"},
+						"test-1": {Name: "test-1"},
+					},
+				},
+			},
+			wantInput: &InputConfiguration{
+				BaseImages: map[string]ImageStreamTagReference{
+					"test-1": {Name: "test-1"},
+				},
+			},
+		},
+		{
+			name:    "map merge by field",
+			base:    `{"base_images":{"test-0":{"name":"test-0","namespace":"0"}}}`,
+			overlay: `{"base_images":{"test-0":{"name":"test-0","namespace":null}}}`,
+			want: &ReleaseBuildConfiguration{
+				InputConfiguration: InputConfiguration{
+					BaseImages: map[string]ImageStreamTagReference{
+						"test-0": {Name: "test-0"},
+					},
+				},
+			},
+			wantInput: &InputConfiguration{
+				BaseImages: map[string]ImageStreamTagReference{
+					"test-0": {Name: "test-0"},
+				},
+			},
+		},
+		{
+			name:    "skips missing key",
+			base:    `{"test_base_image":{}}`,
+			overlay: `{}`,
+			want: &ReleaseBuildConfiguration{
+				InputConfiguration: InputConfiguration{
+					TestBaseImage: &ImageStreamTagReference{},
+				},
+			},
+			wantInput: &InputConfiguration{},
+		},
+		{
+			name:    "clears with explicit null",
+			base:    `{"test_base_image":{}}`,
+			overlay: `{"test_base_image":null}`,
+			want: &ReleaseBuildConfiguration{
+				InputConfiguration: InputConfiguration{},
+			},
+			wantInput: &InputConfiguration{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &ReleaseBuildConfiguration{}
+			input := &InputConfiguration{}
+			if err := json.Unmarshal([]byte(tt.base), config); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal([]byte(tt.overlay), config); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal([]byte(tt.overlay), input); err != nil {
+				t.Fatal(err)
+			}
+			if got := input; !reflect.DeepEqual(got, tt.wantInput) {
+				t.Errorf("input:\n%#v\n%#v", got, tt.wantInput)
+			}
+			if got := config; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("config:\n%#v\n%#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/steps/build_defaults.go
+++ b/pkg/steps/build_defaults.go
@@ -110,13 +110,13 @@ func FromConfig(config *api.ReleaseBuildConfiguration, jobSpec *JobSpec, templat
 			}
 			step = InputImageTagStep(*rawStep.InputImageTagStepConfiguration, srcClient, imageClient, jobSpec)
 		} else if rawStep.PipelineImageCacheStepConfiguration != nil {
-			step = PipelineImageCacheStep(*rawStep.PipelineImageCacheStepConfiguration, buildClient, imageClient, jobSpec)
+			step = PipelineImageCacheStep(*rawStep.PipelineImageCacheStepConfiguration, config.Resources, buildClient, imageClient, jobSpec)
 		} else if rawStep.SourceStepConfiguration != nil {
-			step = SourceStep(*rawStep.SourceStepConfiguration, buildClient, imageClient, jobSpec)
+			step = SourceStep(*rawStep.SourceStepConfiguration, config.Resources, buildClient, imageClient, jobSpec)
 		} else if rawStep.ProjectDirectoryImageBuildStepConfiguration != nil {
-			step = ProjectDirectoryImageBuildStep(*rawStep.ProjectDirectoryImageBuildStepConfiguration, buildClient, imageClient, jobSpec)
+			step = ProjectDirectoryImageBuildStep(*rawStep.ProjectDirectoryImageBuildStepConfiguration, config.Resources, buildClient, imageClient, jobSpec)
 		} else if rawStep.RPMImageInjectionStepConfiguration != nil {
-			step = RPMImageInjectionStep(*rawStep.RPMImageInjectionStepConfiguration, buildClient, routeGetter, imageClient, jobSpec)
+			step = RPMImageInjectionStep(*rawStep.RPMImageInjectionStepConfiguration, config.Resources, buildClient, routeGetter, imageClient, jobSpec)
 		} else if rawStep.RPMServeStepConfiguration != nil {
 			step = RPMServerStep(*rawStep.RPMServeStepConfiguration, deploymentGetter, routeGetter, serviceGetter, imageClient, jobSpec)
 		} else if rawStep.OutputImageTagStepConfiguration != nil {
@@ -130,7 +130,7 @@ func FromConfig(config *api.ReleaseBuildConfiguration, jobSpec *JobSpec, templat
 			step = ReleaseImagesTagStep(*rawStep.ReleaseImagesTagStepConfiguration, srcClient, imageClient, routeGetter, configMapGetter, params, jobSpec)
 			imageStepLinks = append(imageStepLinks, step.Creates()...)
 		} else if rawStep.TestStepConfiguration != nil {
-			step = TestStep(*rawStep.TestStepConfiguration, podClient, artifactDir, jobSpec)
+			step = TestStep(*rawStep.TestStepConfiguration, config.Resources, podClient, artifactDir, jobSpec)
 		}
 		provides, link := step.Provides()
 		for name, fn := range provides {

--- a/pkg/steps/build_defaults_test.go
+++ b/pkg/steps/build_defaults_test.go
@@ -19,8 +19,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 		{
 			name: "minimal information provided",
 			input: &api.ReleaseBuildConfiguration{
-				TestBaseImage: &api.ImageStreamTagReference{
-					Tag: "manual",
+				InputConfiguration: api.InputConfiguration{
+					TestBaseImage: &api.ImageStreamTagReference{Tag: "manual"},
 				},
 			},
 			jobSpec: &JobSpec{
@@ -48,8 +48,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 		{
 			name: "binary build requested",
 			input: &api.ReleaseBuildConfiguration{
-				TestBaseImage: &api.ImageStreamTagReference{
-					Tag: "manual",
+				InputConfiguration: api.InputConfiguration{
+					TestBaseImage: &api.ImageStreamTagReference{Tag: "manual"},
 				},
 				BinaryBuildCommands: "hi",
 			},
@@ -84,8 +84,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 		{
 			name: "binary and rpm build requested",
 			input: &api.ReleaseBuildConfiguration{
-				TestBaseImage: &api.ImageStreamTagReference{
-					Tag: "manual",
+				InputConfiguration: api.InputConfiguration{
+					TestBaseImage: &api.ImageStreamTagReference{Tag: "manual"},
 				},
 				BinaryBuildCommands: "hi",
 				RpmBuildCommands:    "hello",
@@ -131,8 +131,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 		{
 			name: "rpm but not binary build requested",
 			input: &api.ReleaseBuildConfiguration{
-				TestBaseImage: &api.ImageStreamTagReference{
-					Tag: "manual",
+				InputConfiguration: api.InputConfiguration{
+					TestBaseImage: &api.ImageStreamTagReference{Tag: "manual"},
 				},
 				RpmBuildCommands: "hello",
 			},
@@ -171,8 +171,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 		{
 			name: "rpm with custom output but not binary build requested",
 			input: &api.ReleaseBuildConfiguration{
-				TestBaseImage: &api.ImageStreamTagReference{
-					Tag: "manual",
+				InputConfiguration: api.InputConfiguration{
+					TestBaseImage: &api.ImageStreamTagReference{Tag: "manual"},
 				},
 				RpmBuildLocation: "testing",
 				RpmBuildCommands: "hello",
@@ -212,14 +212,16 @@ func TestStepConfigsForBuild(t *testing.T) {
 		{
 			name: "explicit base image requested",
 			input: &api.ReleaseBuildConfiguration{
-				TestBaseImage: &api.ImageStreamTagReference{
-					Tag: "manual",
+				InputConfiguration: api.InputConfiguration{
+					TestBaseImage: &api.ImageStreamTagReference{Tag: "manual"},
+					BaseImages: map[string]api.ImageStreamTagReference{
+						"name": {
+							Namespace: "namespace",
+							Name:      "name",
+							Tag:       "tag",
+						},
+					},
 				},
-				BaseImages: []api.ImageStreamTagReference{{
-					Namespace: "namespace",
-					Name:      "name",
-					Tag:       "tag",
-				}},
 			},
 			jobSpec: &JobSpec{
 				Refs: Refs{
@@ -247,6 +249,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Namespace: "namespace",
 						Name:      "name",
 						Tag:       "tag",
+						As:        "name",
 					},
 					To: api.PipelineImageStreamTagReference("name"),
 				},
@@ -255,14 +258,16 @@ func TestStepConfigsForBuild(t *testing.T) {
 		{
 			name: "rpm base image requested",
 			input: &api.ReleaseBuildConfiguration{
-				TestBaseImage: &api.ImageStreamTagReference{
-					Tag: "manual",
+				InputConfiguration: api.InputConfiguration{
+					TestBaseImage: &api.ImageStreamTagReference{Tag: "manual"},
+					BaseRPMImages: map[string]api.ImageStreamTagReference{
+						"name": {
+							Namespace: "namespace",
+							Name:      "name",
+							Tag:       "tag",
+						},
+					},
 				},
-				BaseRPMImages: []api.ImageStreamTagReference{{
-					Namespace: "namespace",
-					Name:      "name",
-					Tag:       "tag",
-				}},
 			},
 			jobSpec: &JobSpec{
 				Refs: Refs{
@@ -290,6 +295,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Namespace: "namespace",
 						Name:      "name",
 						Tag:       "tag",
+						As:        "name",
 					},
 					To: api.PipelineImageStreamTagReference("name-without-rpms"),
 				},
@@ -372,5 +378,5 @@ func formatStep(step api.StepConfiguration) string {
 }
 
 func formatReference(ref api.ImageStreamTagReference) string {
-	return fmt.Sprintf("%s/%s:%s", ref.Namespace, ref.Name, ref.Tag)
+	return fmt.Sprintf("%s/%s:%s (as:%s)", ref.Namespace, ref.Name, ref.Tag, ref.As)
 }

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -19,6 +19,7 @@ RUN ["/bin/bash", "-c", %s]`, PipelineImageStream, from, strconv.Quote(fmt.Sprin
 
 type pipelineImageCacheStep struct {
 	config      api.PipelineImageCacheStepConfiguration
+	resources   api.ResourceConfiguration
 	buildClient BuildClient
 	imageClient imageclientset.ImageV1Interface
 	jobSpec     *JobSpec
@@ -36,6 +37,7 @@ func (s *pipelineImageCacheStep) Run(ctx context.Context, dry bool) error {
 			Type:       buildapi.BuildSourceDockerfile,
 			Dockerfile: &dockerfile,
 		},
+		s.resources,
 	), dry)
 }
 
@@ -76,9 +78,10 @@ func (s *pipelineImageCacheStep) Provides() (api.ParameterMap, api.StepLink) {
 
 func (s *pipelineImageCacheStep) Name() string { return string(s.config.To) }
 
-func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, jobSpec *JobSpec) api.Step {
+func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, jobSpec *JobSpec) api.Step {
 	return &pipelineImageCacheStep{
 		config:      config,
+		resources:   resources,
 		buildClient: buildClient,
 		imageClient: imageClient,
 		jobSpec:     jobSpec,

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -20,8 +20,7 @@ RUN ["/bin/bash", "-c", %s]`, PipelineImageStream, from, strconv.Quote(fmt.Sprin
 type pipelineImageCacheStep struct {
 	config      api.PipelineImageCacheStepConfiguration
 	buildClient BuildClient
-	istClient   imageclientset.ImageStreamTagsGetter
-	isClient    imageclientset.ImageStreamsGetter
+	imageClient imageclientset.ImageV1Interface
 	jobSpec     *JobSpec
 }
 
@@ -41,7 +40,7 @@ func (s *pipelineImageCacheStep) Run(ctx context.Context, dry bool) error {
 }
 
 func (s *pipelineImageCacheStep) Done() (bool, error) {
-	return imageStreamTagExists(s.config.To, s.istClient.ImageStreamTags(s.jobSpec.Namespace()))
+	return imageStreamTagExists(s.config.To, s.imageClient.ImageStreamTags(s.jobSpec.Namespace()))
 }
 
 func (s *pipelineImageCacheStep) Requires() []api.StepLink {
@@ -58,7 +57,7 @@ func (s *pipelineImageCacheStep) Provides() (api.ParameterMap, api.StepLink) {
 	}
 	return api.ParameterMap{
 		fmt.Sprintf("LOCAL_IMAGE_%s", strings.ToUpper(strings.Replace(string(s.config.To), "-", "_", -1))): func() (string, error) {
-			is, err := s.isClient.ImageStreams(s.jobSpec.Namespace()).Get(PipelineImageStream, meta.GetOptions{})
+			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(PipelineImageStream, meta.GetOptions{})
 			if err != nil {
 				return "", err
 			}
@@ -77,12 +76,11 @@ func (s *pipelineImageCacheStep) Provides() (api.ParameterMap, api.StepLink) {
 
 func (s *pipelineImageCacheStep) Name() string { return string(s.config.To) }
 
-func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, buildClient BuildClient, istClient imageclientset.ImageStreamTagsGetter, isClient imageclientset.ImageStreamsGetter, jobSpec *JobSpec) api.Step {
+func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, jobSpec *JobSpec) api.Step {
 	return &pipelineImageCacheStep{
 		config:      config,
 		buildClient: buildClient,
-		istClient:   istClient,
-		isClient:    isClient,
+		imageClient: imageClient,
 		jobSpec:     jobSpec,
 	}
 }

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -15,6 +15,7 @@ import (
 
 type projectDirectoryImageBuildStep struct {
 	config      api.ProjectDirectoryImageBuildStepConfiguration
+	resources   api.ResourceConfiguration
 	buildClient BuildClient
 	istClient   imageclientset.ImageStreamTagsGetter
 	jobSpec     *JobSpec
@@ -59,6 +60,7 @@ func (s *projectDirectoryImageBuildStep) Run(ctx context.Context, dry bool) erro
 				}},
 			}},
 		},
+		s.resources,
 	), dry)
 }
 
@@ -83,9 +85,10 @@ func (s *projectDirectoryImageBuildStep) Provides() (api.ParameterMap, api.StepL
 
 func (s *projectDirectoryImageBuildStep) Name() string { return string(s.config.To) }
 
-func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, buildClient BuildClient, istClient imageclientset.ImageStreamTagsGetter, jobSpec *JobSpec) api.Step {
+func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, istClient imageclientset.ImageStreamTagsGetter, jobSpec *JobSpec) api.Step {
 	return &projectDirectoryImageBuildStep{
 		config:      config,
+		resources:   resources,
 		buildClient: buildClient,
 		istClient:   istClient,
 		jobSpec:     jobSpec,

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -19,6 +19,7 @@ RUN echo $'[built]\nname = Built RPMs\nbaseurl = http://%s\ngpgcheck = 0\nenable
 
 type rpmImageInjectionStep struct {
 	config      api.RPMImageInjectionStepConfiguration
+	resources   api.ResourceConfiguration
 	buildClient BuildClient
 	routeClient routeclientset.RoutesGetter
 	istClient   imageclientset.ImageStreamTagsGetter
@@ -47,6 +48,7 @@ func (s *rpmImageInjectionStep) Run(ctx context.Context, dry bool) error {
 			Type:       buildapi.BuildSourceDockerfile,
 			Dockerfile: &dockerfile,
 		},
+		s.resources,
 	), dry)
 }
 
@@ -68,9 +70,10 @@ func (s *rpmImageInjectionStep) Provides() (api.ParameterMap, api.StepLink) {
 
 func (s *rpmImageInjectionStep) Name() string { return string(s.config.To) }
 
-func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, buildClient BuildClient, routeClient routeclientset.RoutesGetter, istClient imageclientset.ImageStreamTagsGetter, jobSpec *JobSpec) api.Step {
+func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, routeClient routeclientset.RoutesGetter, istClient imageclientset.ImageStreamTagsGetter, jobSpec *JobSpec) api.Step {
 	return &rpmImageInjectionStep{
 		config:      config,
+		resources:   resources,
 		buildClient: buildClient,
 		routeClient: routeClient,
 		istClient:   istClient,

--- a/test/config.json
+++ b/test/config.json
@@ -7,14 +7,13 @@
   "binary_build_commands": "make build",
   "test_binary_build_commands": "OS_GOFLAGS='-race' make build",
   "rpm_build_commands": "make build-rpms",
-  "base_rpm_images": [
-    {
+  "base_rpm_images": {
+    "base": {
       "namespace": "openshift",
       "name": "origin-v3.10",
-      "tag": "base",
-      "as": "base"
+      "tag": "base"
     }
-  ],
+  },
   "images": [
     {
       "from": "base",


### PR DESCRIPTION
Fixes #17

Allows us to separate out CI job definitions provided with the repo from the inputs we want to use.