### PR TITLE
Have the pod wait loop trigger artifact collection early

### DIFF
--- a/pkg/steps/test.go
+++ b/pkg/steps/test.go
@@ -69,12 +69,13 @@ func (s *testStep) Run(ctx context.Context, dry bool) error {
 	if err != nil {
 		return err
 	}
+	if notifier == nil {
+		notifier = NopNotifier
+	}
 
 	go func() {
 		<-ctx.Done()
-		if notifier != nil {
-			notifier.Cancel()
-		}
+		notifier.Cancel()
 		log.Printf("cleanup: Deleting test pod %s", s.config.As)
 		if err := s.podClient.Pods(s.jobSpec.Namespace()).Delete(s.config.As, nil); err != nil && !errors.IsNotFound(err) {
 			log.Printf("error: Could not delete test pod: %v", err)


### PR DESCRIPTION
We shouldn't have to wait for all containers once a failure happens,
because artifacts are likely to be coming from the first failed
container.