### PR TITLE
Add a promotion definition that will copy pipeline tags out

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -31,6 +31,16 @@ type StepLink interface {
 	Matches(other StepLink) bool
 }
 
+func AllStepsLink() StepLink {
+	return allStepsLink{}
+}
+
+type allStepsLink struct{}
+
+func (_ allStepsLink) Matches(other StepLink) bool {
+	return true
+}
+
 func ExternalImageLink(ref ImageStreamTagReference) StepLink {
 	return &externalImageLink{image: ref}
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -42,6 +42,13 @@ type ReleaseBuildConfiguration struct {
 	// included in the final pipeline.
 	RawSteps []StepConfiguration `json:"raw_steps,omitempty"`
 
+	// PromotionConfiguration determines how images are promoted
+	// by this command. It is ignored unless promotion has specifically
+	// been requested. Promotion is performed after all other steps
+	// have been completed so that tests can be run prior to promotion.
+	// If no promotion is defined, it is defaulted from the ReleaseTagConfiguration.
+	PromotionConfiguration *PromotionConfiguration `json:"promotion,omitempty"`
+
 	// Resources is a set of resource requests or limits over the
 	// input types. The special name '*' may be used to set default
 	// requests and limits.
@@ -127,7 +134,7 @@ type ImageStreamTagReference struct {
 }
 
 // ReleaseTagConfiguration describes how a release is
-// assembled from release arifacts. There are two primary modes,
+// assembled from release artifacts. There are two primary modes,
 // single stream, multiple tags (openshift/origin-v3.9:control-plane)
 // on one stream, or multiple streams with one tag
 // (openshift/origin-control-plane:v3.9). The former works well for
@@ -163,6 +170,28 @@ type ReleaseTagConfiguration struct {
 	// above namespace to be tagged in at a different
 	// level than the rest.
 	TagOverrides map[string]string `json:"tag_overrides"`
+}
+
+// PromotionConfiguration describes where images created by this
+// config should be published to. The release tag configuration
+// defines the inputs, while this defines the outputs.
+type PromotionConfiguration struct {
+	// Namespace identifies the namespace to which the built
+	// artifacts will be published to.
+	Namespace string `json:"namespace"`
+
+	// Name is an optional image stream name to use that
+	// contains all component tags. If specified, tag is
+	// ignored.
+	Name string `json:"name"`
+
+	// Tag is the ImageStreamTag tagged in for each
+	// build image's ImageStream.
+	Tag string `json:"tag"`
+
+	// NamePrefix is prepended to the final output image name
+	// if specified.
+	NamePrefix string `json:"name_prefix"`
 }
 
 // StepConfiguration holds one step configuration.
@@ -208,6 +237,9 @@ type PipelineImageCacheStepConfiguration struct {
 	Commands string `json:"commands"`
 }
 
+// TestStepConfiguration describes a step that runs a
+// command in one of the previously built images and then
+// gathers artifacts from that step.
 type TestStepConfiguration struct {
 	// As is the name of the test.
 	As string `json:"as"`

--- a/pkg/steps/promote.go
+++ b/pkg/steps/promote.go
@@ -1,0 +1,148 @@
+package steps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	imageapi "github.com/openshift/api/image/v1"
+	"github.com/openshift/ci-operator/pkg/api"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// promotionStep will tag a full release suite
+// of images out to the configured namespace.
+type promotionStep struct {
+	config api.PromotionConfiguration
+	// tags is the set of all tags to attempt to copy over
+	tags      []string
+	srcClient imageclientset.ImageV1Interface
+	dstClient imageclientset.ImageV1Interface
+	jobSpec   *JobSpec
+}
+
+func targetName(config api.PromotionConfiguration) string {
+	if len(config.Name) > 0 {
+		return fmt.Sprintf("%s/%s:${component}", config.Namespace, config.Name)
+	}
+	return fmt.Sprintf("%s/${component}:%s", config.Namespace, config.Tag)
+}
+
+func (s *promotionStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
+	return nil, nil
+}
+
+func (s *promotionStep) Run(ctx context.Context, dry bool) error {
+	log.Printf("Promoting tags to %s: %s", targetName(s.config), strings.Join(s.tags, ", "))
+
+	pipeline, err := s.srcClient.ImageStreams(s.jobSpec.Namespace()).Get(PipelineImageStream, meta.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("could not resolve pipeline imagestream: %v", err)
+	}
+
+	if len(s.config.Name) > 0 {
+		is, err := s.dstClient.ImageStreams(s.config.Namespace).Get(s.config.Name, meta.GetOptions{})
+		if errors.IsNotFound(err) {
+			is, err = s.dstClient.ImageStreams(s.config.Namespace).Create(&imageapi.ImageStream{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      s.config.Name,
+					Namespace: s.config.Namespace,
+				},
+			})
+		}
+		if err != nil {
+			return fmt.Errorf("could not retrieve target imagestream: %v", err)
+		}
+
+		for _, tag := range s.tags {
+			if valid, _ := findStatusTag(pipeline, tag); valid != nil {
+				is.Spec.Tags = append(is.Spec.Tags, imageapi.TagReference{
+					Name: tag,
+					From: valid,
+				})
+			}
+		}
+
+		if dry {
+			istJSON, err := json.Marshal(is)
+			if err != nil {
+				return fmt.Errorf("failed to marshal image stream: %v", err)
+			}
+			fmt.Printf("%s\n", istJSON)
+			return nil
+		}
+		is, err = s.dstClient.ImageStreams(s.config.Namespace).Update(is)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("could not promote image streams: %v", err)
+		}
+
+		return nil
+	}
+
+	client := s.dstClient.ImageStreamTags(s.config.Namespace)
+	for _, tag := range s.tags {
+		valid, _ := findStatusTag(pipeline, tag)
+		if valid == nil {
+			continue
+		}
+		ist := &imageapi.ImageStreamTag{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      fmt.Sprintf("%s%s:%s", s.config.NamePrefix, tag, s.config.Tag),
+				Namespace: s.config.Namespace,
+			},
+			Tag: &imageapi.TagReference{
+				Name: s.config.Tag,
+				From: valid,
+			},
+		}
+		if dry {
+			istJSON, err := json.Marshal(ist)
+			if err != nil {
+				return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
+			}
+			fmt.Printf("%s\n", istJSON)
+			continue
+		}
+		_, err := client.Update(ist)
+		if err != nil {
+			return fmt.Errorf("could not promote imagestreamtag %s: %v", tag, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *promotionStep) Done() (bool, error) {
+	// TODO: define done
+	return true, nil
+}
+
+func (s *promotionStep) Requires() []api.StepLink {
+	return []api.StepLink{api.AllStepsLink()}
+}
+
+func (s *promotionStep) Creates() []api.StepLink {
+	return []api.StepLink{}
+}
+
+func (s *promotionStep) Provides() (api.ParameterMap, api.StepLink) {
+	return nil, nil
+}
+
+func (s *promotionStep) Name() string { return "" }
+
+// PromotionStep copies tags from the pipeline image stream to the destination defined in the promotion config.
+// If the source tag does not exist it is silently skippe.d
+func PromotionStep(config api.PromotionConfiguration, tags []string, srcClient, dstClient imageclientset.ImageV1Interface, jobSpec *JobSpec) api.Step {
+	return &promotionStep{
+		config:    config,
+		tags:      tags,
+		srcClient: srcClient,
+		dstClient: dstClient,
+		jobSpec:   jobSpec,
+	}
+}


### PR DESCRIPTION
Branch jobs should be able to promote the known tags to a target
location when needed. The alternative is to duplicate the list of images
known in the config, which complicates setup. --promote is an optional
flag that instructs the ci-operator to also attempt a promotion. This
prevents the job from being able to automatically promote (when in a
repo config). The promotion step is executed after the graph and
promotes anything that was successfully built.

@kargakis @stevekuznetsov last step to have a branch job publish images back to the converged list