### PR TITLE
Improvements to support multi-stage builds and cleaner go The context_dir and docker path don't always align. Add dockerfile_path and pass that to the build. Also, for multistage builds and reuse of previous artifacts add a new `inputs` map that creates build api ImageSource items from an existing pipeline image ref. Example:

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -22,6 +22,12 @@ type ReleaseBuildConfiguration struct {
 	TestBinaryBuildCommands string `json:"test_binary_build_commands,omitempty"`
 	RpmBuildCommands        string `json:"rpm_build_commands,omitempty"`
 
+	// CanonicalGoRepository is a directory path that represents
+	// the desired location of the contents of this repository in
+	// Go. If specified the location of the repository we are
+	// cloning from is ignored.
+	CanonicalGoRepository string `json:"canonical_go_repository"`
+
 	// RpmBuildLocation is where RPms are deposited
 	// after being built. If unset, this will default
 	// under the repository root to
@@ -277,6 +283,11 @@ const (
 type SourceStepConfiguration struct {
 	From PipelineImageStreamTagReference `json:"from"`
 	To   PipelineImageStreamTagReference `json:"to,omitempty"`
+
+	// SourcePath is the location within the source repository
+	// to place source contents. It defaults to
+	// github.com/ORG/REPO.
+	PathAlias string `json:"source_path"`
 }
 
 // ProjectDirectoryImageBuildStepConfiguration describes an

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -299,6 +299,39 @@ type ProjectDirectoryImageBuildStepConfiguration struct {
 	// ContextDir is the directory in the project
 	// from which this build should be run.
 	ContextDir string `json:"context_dir"`
+
+	// DockerfilePath is the path to a Dockerfile in the
+	// project to run relative to the context_dir.
+	DockerfilePath string `json:"dockerfile_path"`
+
+	// Inputs is a map of tag reference name to image input changes
+	// that will populate the build context for the Dockerfile or
+	// alter the input image for a multi-stage build.
+	Inputs map[string]ImageBuildInputs `json:"inputs"`
+}
+
+// ImageBuildInputs is a subset of the v1 OpenShift Build API object
+// defining an input source.
+type ImageBuildInputs struct {
+	// Paths is a list of paths to copy out of this image and into the
+	// context directory.
+	Paths []ImageSourcePath `json:"paths"`
+	// As is a list of multi-stage step names or image names that will
+	// be replaced by the image reference from this step. For instance,
+	// if the Dockerfile defines FROM nginx:latest AS base, specifying
+	// either "nginx:latest" or "base" in this array will replace that
+	// image with the pipeline input.
+	As []string `json:"as"`
+}
+
+// ImageSourcePath maps a path in the source image into a destination
+// path in the context. See the v1 OpenShift Build API for more info.
+type ImageSourcePath struct {
+	// SourcePath is a file or directory in the source image to copy from.
+	SourcePath string `json:"source_path"`
+	// DestinationDir is the directory in the destination image to copy
+	// to.
+	DestinationDir string `json:"destination_dir"`
 }
 
 // RPMImageInjectionStepConfiguration describes a step

--- a/pkg/steps/build_defaults.go
+++ b/pkg/steps/build_defaults.go
@@ -250,8 +250,9 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *JobSpec
 	}
 
 	buildSteps = append(buildSteps, api.StepConfiguration{SourceStepConfiguration: &api.SourceStepConfiguration{
-		From: api.PipelineImageStreamTagReferenceRoot,
-		To:   api.PipelineImageStreamTagReferenceSource,
+		From:      api.PipelineImageStreamTagReferenceRoot,
+		To:        api.PipelineImageStreamTagReferenceSource,
+		PathAlias: config.CanonicalGoRepository,
 	}})
 
 	if target := config.InputConfiguration.TestBaseImage; target != nil {

--- a/pkg/steps/job_spec.go
+++ b/pkg/steps/job_spec.go
@@ -56,6 +56,8 @@ type Refs struct {
 	BaseSHA string `json:"base_sha,omitempty"`
 
 	Pulls []Pull `json:"pulls,omitempty"`
+
+	PathAlias string `json:"path_alias,omitempty"`
 }
 
 func (r Refs) String() string {

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -37,6 +37,7 @@ func (s *pipelineImageCacheStep) Run(ctx context.Context, dry bool) error {
 			Type:       buildapi.BuildSourceDockerfile,
 			Dockerfile: &dockerfile,
 		},
+		"",
 		s.resources,
 	), dry)
 }

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -48,6 +48,7 @@ func (s *rpmImageInjectionStep) Run(ctx context.Context, dry bool) error {
 			Type:       buildapi.BuildSourceDockerfile,
 			Dockerfile: &dockerfile,
 		},
+		"",
 		s.resources,
 	), dry)
 }


### PR DESCRIPTION
The context_dir and docker path don't always align. Add dockerfile_path and pass that to the build. Also, for multistage builds and reuse of previous artifacts add a new `inputs` map that creates build api ImageSource items from an existing pipeline image ref. Example:

```
 "images": [
   {
     "from": "base",
     "to": "installer",
     "dockerfile_path": "images/tectonic-installer/Dockerfile.ci",
     "inputs": {
       "bin": {"paths": [{"source_path":
"/go/src/github.com/coreos/tectonic-installer/tectonic",
"destination_dir": "."}]},
       "root": {"as": ["build"]}
     }
   }
 ],
```

Finally, make the from ref optional for cases where we want to using the
dockerfile's base image.

Allow canonical Go path to be passed as clone location

Removes a ton of boilerplate from jobs. Eventually, this could be smarter /
detectable.