### PR TITLE
Improve debugging of what steps are being run

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -228,3 +228,18 @@ func HasAnyLinks(steps, candidates []StepLink) bool {
 	}
 	return false
 }
+
+func HasAllLinks(needles, haystack []StepLink) bool {
+	for _, needle := range needles {
+		contains := false
+		for _, hay := range haystack {
+			if hay.Matches(needle) {
+				contains = true
+			}
+		}
+		if !contains {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -122,7 +122,7 @@ func (s *inputImageTagStep) Done() (bool, error) {
 }
 
 func (s *inputImageTagStep) Requires() []api.StepLink {
-	return []api.StepLink{api.ExternalImageLink(s.config.BaseImage)}
+	return nil //[]api.StepLink{api.ExternalImageLink(s.config.BaseImage)}
 }
 
 func (s *inputImageTagStep) Creates() []api.StepLink {

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -133,7 +133,7 @@ func (s *inputImageTagStep) Provides() (api.ParameterMap, api.StepLink) {
 	return nil, nil
 }
 
-func (s *inputImageTagStep) Name() string { return "" }
+func (s *inputImageTagStep) Name() string { return fmt.Sprintf("[input:%s]", s.config.To) }
 
 func InputImageTagStep(config api.InputImageTagStepConfiguration, srcClient, dstClient imageclientset.ImageV1Interface, jobSpec *JobSpec) api.Step {
 	return &inputImageTagStep{

--- a/pkg/steps/release_images.go
+++ b/pkg/steps/release_images.go
@@ -305,7 +305,7 @@ func (s *releaseImagesTagStep) Provides() (api.ParameterMap, api.StepLink) {
 	}, api.ImagesReadyLink()
 }
 
-func (s *releaseImagesTagStep) Name() string { return "" }
+func (s *releaseImagesTagStep) Name() string { return "[release-inputs]" }
 
 func ReleaseImagesTagStep(config api.ReleaseTagConfiguration, srcClient, dstClient imageclientset.ImageV1Interface, routeClient routeclientset.RoutesGetter, configMapClient coreclientset.ConfigMapsGetter, params *DeferredParameters, jobSpec *JobSpec) api.Step {
 	return &releaseImagesTagStep{

--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -46,7 +46,7 @@ func Run(ctx context.Context, graph []*api.StepNode, dry bool) error {
 					// We can ignore the child if it does not have prerequisites
 					// finished as we know that we will process it here again
 					// when the last of its parents finishes.
-					if containsAll(child.Step.Requires(), seen) {
+					if api.HasAllLinks(child.Step.Requires(), seen) {
 						wg.Add(1)
 						go runStep(ctx, child, results, dry)
 					}
@@ -85,19 +85,4 @@ func runStep(ctx context.Context, node *api.StepNode, out chan<- message, dry bo
 		node: node,
 		err:  err,
 	}
-}
-
-func containsAll(needles, haystack []api.StepLink) bool {
-	for _, needle := range needles {
-		contains := false
-		for _, hay := range haystack {
-			if hay.Matches(needle) {
-				contains = true
-			}
-		}
-		if !contains {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Print a topological sort of the steps, give steps names:

```
2018/06/08 20:27:13 Running [input:root], [input:base], [release-inputs], src, [images], test-bin, unit
```