### PR TITLE
Inject clonerefs into the source builds

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -289,10 +289,15 @@ type SourceStepConfiguration struct {
 	From PipelineImageStreamTagReference `json:"from"`
 	To   PipelineImageStreamTagReference `json:"to,omitempty"`
 
-	// SourcePath is the location within the source repository
+	// PathAlias is the location within the source repository
 	// to place source contents. It defaults to
 	// github.com/ORG/REPO.
 	PathAlias string `json:"source_path"`
+	// ClonerefsImage is the image where we get the clonerefs tool
+	ClonerefsImage ImageStreamTagReference `json:"clonerefs_image"`
+	// ClonerefsPath is the path in the above image where the
+	// clonerefs tool is placed
+	ClonerefsPath string `json:"clonerefs_path"`
 }
 
 // ProjectDirectoryImageBuildStepConfiguration describes an


### PR DESCRIPTION
We do not want users to have to inject our infrastructure tools into
their test containers, so we can do it ourselves before we need to use
them.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 
This is going to add a bunch of boilerplate I guess