### PR TITLE
Support additional image promotions during promote

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -108,6 +108,11 @@ Errors in artifact extraction will not cause build failures.
 In CI environments the inputs to a job may be different than what a normal
 development workflow would use. The --override file will override fields
 defined in the config file, such as base images and the release tag configuration.
+
+After a successful build the --promote will tag each built image (in "images")
+to the image stream(s) identified by the "promotion" config, which defaults to
+the same image stream as the release configuration. You may add additional 
+images to promote and their target names via the "additional_images" map.
 `
 
 func main() {
@@ -268,6 +273,13 @@ func (o *options) Complete() error {
 	}
 	jobSpec.SetBaseNamespace(o.baseNamespace)
 	o.jobSpec = jobSpec
+
+	if o.dry {
+		config, _ := json.MarshalIndent(o.configSpec, "", "  ")
+		log.Printf("Resolved configuration:\n%s", string(config))
+		job, _ := json.MarshalIndent(o.jobSpec, "", "  ")
+		log.Printf("Resolved job spec:\n%s", string(job))
+	}
 
 	for _, path := range o.secretDirectories.values {
 		secret := &coreapi.Secret{Data: make(map[string][]byte)}

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -716,7 +716,7 @@ func nodeNames(nodes []*api.StepNode) []string {
 func linkNames(links []api.StepLink) []string {
 	var names []string
 	for _, link := range links {
-		name := fmt.Sprintf("<%T>", link)
+		name := fmt.Sprintf("<%#v>", link)
 		names = append(names, name)
 	}
 	return names
@@ -752,6 +752,7 @@ func topologicalSort(nodes []*api.StepNode) ([]*api.StepNode, error) {
 			for _, node := range waiting {
 				links = append(links, node.Step.Requires()...)
 			}
+			links = api.Reduce(links)
 			var unsatisfied []api.StepLink
 			for _, link := range links {
 				if !api.HasAllLinks([]api.StepLink{link}, satisfied) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -203,6 +203,13 @@ type PromotionConfiguration struct {
 	// NamePrefix is prepended to the final output image name
 	// if specified.
 	NamePrefix string `json:"name_prefix"`
+
+	// AdditionalImages is a mapping of images to promote. The
+	// images will be taken from the pipeline image stream. The
+	// key is the name to promote as and the value is the source
+	// name. If you specify a tag that does not exist as the source
+	// the destination tag will not be created.
+	AdditionalImages map[string]string `json:"additional_images"`
 }
 
 // StepConfiguration holds one step configuration.

--- a/pkg/steps/build_defaults_test.go
+++ b/pkg/steps/build_defaults_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/openshift/ci-operator/pkg/api"
 )
 
+func addCloneRefs(cfg *api.SourceStepConfiguration) *api.SourceStepConfiguration {
+	cfg.ClonerefsImage = api.ImageStreamTagReference{Cluster: "https://api.ci.openshift.org", Namespace: "ci", Name: "clonerefs", Tag: "latest"}
+	cfg.ClonerefsPath = "/clonerefs"
+	return cfg
+}
+
 func TestStepConfigsForBuild(t *testing.T) {
 	var testCases = []struct {
 		name    string
@@ -30,10 +36,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 				baseNamespace: "base-1",
 			},
 			output: []api.StepConfiguration{{
-				SourceStepConfiguration: &api.SourceStepConfiguration{
+				SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
 					From: api.PipelineImageStreamTagReferenceRoot,
 					To:   api.PipelineImageStreamTagReferenceSource,
-				},
+				}),
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 					BaseImage: api.ImageStreamTagReference{
@@ -60,10 +66,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 				baseNamespace: "base-1",
 			},
 			output: []api.StepConfiguration{{
-				SourceStepConfiguration: &api.SourceStepConfiguration{
+				SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
 					From: api.PipelineImageStreamTagReferenceRoot,
 					To:   api.PipelineImageStreamTagReferenceSource,
-				},
+				}),
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 					BaseImage: api.ImageStreamTagReference{
@@ -97,10 +103,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 				baseNamespace: "base-1",
 			},
 			output: []api.StepConfiguration{{
-				SourceStepConfiguration: &api.SourceStepConfiguration{
+				SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
 					From: api.PipelineImageStreamTagReferenceRoot,
 					To:   api.PipelineImageStreamTagReferenceSource,
-				},
+				}),
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 					BaseImage: api.ImageStreamTagReference{
@@ -143,10 +149,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 				baseNamespace: "base-1",
 			},
 			output: []api.StepConfiguration{{
-				SourceStepConfiguration: &api.SourceStepConfiguration{
+				SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
 					From: api.PipelineImageStreamTagReferenceRoot,
 					To:   api.PipelineImageStreamTagReferenceSource,
-				},
+				}),
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 					BaseImage: api.ImageStreamTagReference{
@@ -184,10 +190,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 				baseNamespace: "base-1",
 			},
 			output: []api.StepConfiguration{{
-				SourceStepConfiguration: &api.SourceStepConfiguration{
+				SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
 					From: api.PipelineImageStreamTagReferenceRoot,
 					To:   api.PipelineImageStreamTagReferenceSource,
-				},
+				}),
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 					BaseImage: api.ImageStreamTagReference{
@@ -230,10 +236,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 				baseNamespace: "base-1",
 			},
 			output: []api.StepConfiguration{{
-				SourceStepConfiguration: &api.SourceStepConfiguration{
+				SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
 					From: api.PipelineImageStreamTagReferenceRoot,
 					To:   api.PipelineImageStreamTagReferenceSource,
-				},
+				}),
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 					BaseImage: api.ImageStreamTagReference{
@@ -276,10 +282,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 				baseNamespace: "base-1",
 			},
 			output: []api.StepConfiguration{{
-				SourceStepConfiguration: &api.SourceStepConfiguration{
+				SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
 					From: api.PipelineImageStreamTagReferenceRoot,
 					To:   api.PipelineImageStreamTagReferenceSource,
-				},
+				}),
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 					BaseImage: api.ImageStreamTagReference{

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -82,7 +82,7 @@ func (s *inputImageTagStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	if dry {
-		istJSON, err := json.Marshal(ist)
+		istJSON, err := json.MarshalIndent(ist, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
 		}

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -57,7 +57,7 @@ func (s *outputImageTagStep) Run(ctx context.Context, dry bool) error {
 		},
 	}
 	if dry {
-		istJSON, err := json.Marshal(ist)
+		istJSON, err := json.MarshalIndent(ist, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
 		}

--- a/pkg/steps/promote.go
+++ b/pkg/steps/promote.go
@@ -68,7 +68,7 @@ func (s *promotionStep) Run(ctx context.Context, dry bool) error {
 		}
 
 		if dry {
-			istJSON, err := json.Marshal(is)
+			istJSON, err := json.MarshalIndent(is, "", "  ")
 			if err != nil {
 				return fmt.Errorf("failed to marshal image stream: %v", err)
 			}
@@ -100,7 +100,7 @@ func (s *promotionStep) Run(ctx context.Context, dry bool) error {
 			},
 		}
 		if dry {
-			istJSON, err := json.Marshal(ist)
+			istJSON, err := json.MarshalIndent(ist, "", "  ")
 			if err != nil {
 				return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
 			}

--- a/pkg/steps/release_images.go
+++ b/pkg/steps/release_images.go
@@ -113,7 +113,7 @@ func (s *releaseImagesTagStep) Run(ctx context.Context, dry bool) error {
 		}
 
 		if dry {
-			istJSON, err := json.Marshal(newIS)
+			istJSON, err := json.MarshalIndent(newIS, "", "  ")
 			if err != nil {
 				return fmt.Errorf("failed to marshal image stream: %v", err)
 			}
@@ -191,7 +191,7 @@ func (s *releaseImagesTagStep) Run(ctx context.Context, dry bool) error {
 				}
 
 				if dry {
-					istJSON, err := json.Marshal(ist)
+					istJSON, err := json.MarshalIndent(ist, "", "  ")
 					if err != nil {
 						return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
 					}
@@ -249,7 +249,7 @@ func (s *releaseImagesTagStep) createReleaseConfigMap(dry bool) error {
 		},
 	}
 	if dry {
-		cmJSON, err := json.Marshal(cm)
+		cmJSON, err := json.MarshalIndent(cm, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal configmap: %v", err)
 		}

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -113,7 +113,7 @@ func (s *rpmServerStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	if dry {
-		deploymentConfigJSON, err := json.Marshal(deploymentConfig)
+		deploymentConfigJSON, err := json.MarshalIndent(deploymentConfig, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal deploymentconfig: %v", err)
 		}
@@ -140,7 +140,7 @@ func (s *rpmServerStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	if dry {
-		serviceJSON, err := json.Marshal(service)
+		serviceJSON, err := json.MarshalIndent(service, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal service: %v", err)
 		}
@@ -164,7 +164,7 @@ func (s *rpmServerStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	if dry {
-		routeJSON, err := json.Marshal(route)
+		routeJSON, err := json.MarshalIndent(route, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal route: %v", err)
 		}

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -149,11 +149,11 @@ func buildFromSource(jobSpec *JobSpec, fromTag, toTag api.PipelineImageStreamTag
 				Strategy: buildapi.BuildStrategy{
 					Type: buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{
-						DockerfilePath:          dockerfilePath,
-						From:                    from,
-						ForcePull:               true,
-						NoCache:                 true,
-						Env:                     []coreapi.EnvVar{},
+						DockerfilePath: dockerfilePath,
+						From:           from,
+						ForcePull:      true,
+						NoCache:        true,
+						Env:            []coreapi.EnvVar{},
 						ImageOptimizationPolicy: &layer,
 					},
 				},
@@ -201,7 +201,7 @@ func buildInputsFromStep(inputs map[string]api.ImageBuildInputs) []buildapi.Imag
 
 func handleBuild(buildClient BuildClient, build *buildapi.Build, dry bool) error {
 	if dry {
-		buildJSON, err := json.Marshal(build)
+		buildJSON, err := json.MarshalIndent(build, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal build: %v", err)
 		}


### PR DESCRIPTION
The user can add an additional promotion step for images that aren't in the
images list (so we can promote a base image, or an input image, or rename
an image into multiple spots).

Used by origin to push origin-base.

```
  "promotion": {
    "namespace": "ci",
    "name": "test-stable",
    "additional_images": {
      "base": "base",
      "rpms": "rpms",
      "src": "src"
    }
  },

```