### PR TITLE
Perform a submodule init on the cloned code

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -44,7 +44,9 @@ func sourceDockerfile(fromTag api.PipelineImageStreamTagReference, pathAlias str
 FROM %s:%s
 ADD ./clonerefs /clonerefs
 RUN umask 0002 && /clonerefs && chmod g+xw -R /go/src
-WORKDIR /go/src/%s/`, PipelineImageStream, fromTag, workingDir)
+WORKDIR /go/src/%s/
+RUN git submodule update --init
+`, PipelineImageStream, fromTag, workingDir)
 }
 
 type sourceStep struct {


### PR DESCRIPTION
Not currently optional, but could be made so. Required for
openshift/origin-aggregated-logging

@stevekuznetsov if we make this optional i think it should be a boolean on the top level - but i'm not sure what scenario you have a git submodule in your repo that you don't need it for normal workloads.