### PR TITLE
Add an `optional` field to project images and output images

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -355,7 +355,7 @@ func (o *options) Run() error {
 	}()
 
 	// load the graph from the configuration
-	buildSteps, postSteps, err := steps.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig)
+	buildSteps, postSteps, err := steps.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, o.targets.values)
 	if err != nil {
 		return fmt.Errorf("failed to generate steps from config: %v", err)
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -240,6 +240,11 @@ type InputImageTagStepConfiguration struct {
 type OutputImageTagStepConfiguration struct {
 	From PipelineImageStreamTagReference `json:"from"`
 	To   ImageStreamTagReference         `json:"to"`
+
+	// Optional means the output step is not built, published, or
+	// promoted unless explicitly targeted. Use for builds which
+	// are invoked only when testing certain parts of the repo.
+	Optional bool `json:"optional"`
 }
 
 // PipelineImageCacheStepConfiguration describes a
@@ -325,6 +330,11 @@ type ProjectDirectoryImageBuildStepConfiguration struct {
 	// that will populate the build context for the Dockerfile or
 	// alter the input image for a multi-stage build.
 	Inputs map[string]ImageBuildInputs `json:"inputs"`
+
+	// Optional means the build step is not built, published, or
+	// promoted unless explicitly targeted. Use for builds which
+	// are invoked only when testing certain parts of the repo.
+	Optional bool `json:"optional"`
 }
 
 // ImageBuildInputs is a subset of the v1 OpenShift Build API object


### PR DESCRIPTION
Optional images are not included in `[images]` or promotion by default,
but must be explicitly referenced in the `--target`. Will be used for
the artifact build in OpenShift which has build-cross and the RPMs in it
- the image is useful, but we only need to generate it in some jobs.
  Rather than separate its definition into its own config.json, we
make it optional.