### PR TITLE
RPM_REPO should be a URL, not a bare host

### DIFF
--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -299,7 +299,7 @@ func (s *rpmServerStep) Provides() (api.ParameterMap, api.StepLink) {
 			}); err != nil {
 				return "", fmt.Errorf("retrieving RPM_REPO: %v", err)
 			}
-			return repoHost, nil
+			return fmt.Sprintf("http://%s", repoHost), nil
 		},
 	}, api.RPMRepoLink()
 }


### PR DESCRIPTION
Only templates rely on this behavior