### PR TITLE
When pods and builds fail, report more information about them

### DIFF
--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -52,6 +52,11 @@ func Run(ctx context.Context, graph []*api.StepNode, dry bool) (*junit.TestSuite
 			suite.NumTests++
 			if out.err != nil {
 				testCase.FailureOutput = &junit.FailureOutput{Output: out.err.Error()}
+				if o, ok := out.err.(withOutput); ok {
+					if out := o.ErrorOutput(); len(out) > 0 {
+						testCase.FailureOutput.Output += "\n\n" + o.ErrorOutput()
+					}
+				}
 				suite.NumFailed++
 				errors = append(errors, out.err)
 			} else {
@@ -80,6 +85,10 @@ func Run(ctx context.Context, graph []*api.StepNode, dry bool) (*junit.TestSuite
 			return suites, aggregateError(errors)
 		}
 	}
+}
+
+type withOutput interface {
+	ErrorOutput() string
 }
 
 func aggregateError(errors []error) error {

--- a/pkg/steps/test.go
+++ b/pkg/steps/test.go
@@ -45,10 +45,11 @@ func (s *testStep) Run(ctx context.Context, dry bool) error {
 			RestartPolicy: coreapi.RestartPolicyNever,
 			Containers: []coreapi.Container{
 				{
-					Name:      "test",
-					Image:     fmt.Sprintf("%s:%s", PipelineImageStream, s.config.From),
-					Command:   []string{"/bin/sh", "-c", "#!/bin/sh\nset -eu\n" + s.config.Commands},
-					Resources: containerResources,
+					Name:                     "test",
+					Image:                    fmt.Sprintf("%s:%s", PipelineImageStream, s.config.From),
+					Command:                  []string{"/bin/sh", "-c", "#!/bin/sh\nset -eu\n" + s.config.Commands},
+					Resources:                containerResources,
+					TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 		},


### PR DESCRIPTION
Some jobs were being OOMKilled, but the data was not being reported back
so it wasn't obvious that the container needed memory adjustments. For
both builds and pods, try to capture the reason the pod failed and also
include termination message. Use terminationMessagePath fallback to logs
on pods we run in order to capture their last few lines.

Write the extended error output to the junit report if captured.

@stevekuznetsov this reports back better status, but we won't get build results until https://bugzilla.redhat.com/show_bug.cgi?id=1596440 and https://bugzilla.redhat.com/show_bug.cgi?id=1596449 are fixed. For now, if we see GenericBuildError it's almost certain "OOMKill".

@bparees this was why a bunch of ci-operator jobs were bailing out early.