### PR TITLE
Allow a project image build to override the "src" injection

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -189,6 +189,9 @@ func buildInputsFromStep(inputs map[string]api.ImageBuildInputs) []buildapi.Imag
 		for _, path := range value.Paths {
 			paths = append(paths, buildapi.ImageSourcePath{SourcePath: path.SourcePath, DestinationDir: path.DestinationDir})
 		}
+		if len(value.As) == 0 && len(paths) == 0 {
+			continue
+		}
 		refs = append(refs, buildapi.ImageSource{
 			From: coreapi.ObjectReference{
 				Kind: "ImageStreamTag",


### PR DESCRIPTION
Some jobs may want to build their own context, so allow an empty 'src'
build input to override the default injected one.

```
"inputs": {
  "rpms":      {"as": ["rpms"]},
  "src":       {}
},
```

will not include the `src` image.

Used by the artifact build in origin to grab zips and rpms and a custom dockerfile.