### PR TITLE
Allow promotion to be defaulted when non-nil

### DIFF
--- a/pkg/steps/build_defaults.go
+++ b/pkg/steps/build_defaults.go
@@ -192,8 +192,10 @@ func FromConfig(
 func promotionDefaults(configSpec *api.ReleaseBuildConfiguration) (*api.PromotionConfiguration, error) {
 	config := configSpec.PromotionConfiguration
 	if config == nil {
+		config = &api.PromotionConfiguration{}
+	}
+	if len(config.Tag) == 0 && len(config.Name) == 0 {
 		if input := configSpec.ReleaseTagConfiguration; input != nil {
-			config = &api.PromotionConfiguration{}
 			config.Namespace = input.Namespace
 			config.Name = input.Name
 			config.NamePrefix = input.NamePrefix

--- a/pkg/steps/promote.go
+++ b/pkg/steps/promote.go
@@ -153,7 +153,7 @@ func (s *promotionStep) Description() string {
 }
 
 // PromotionStep copies tags from the pipeline image stream to the destination defined in the promotion config.
-// If the source tag does not exist it is silently skippe.d
+// If the source tag does not exist it is silently skipped.
 func PromotionStep(config api.PromotionConfiguration, tags []string, srcClient, dstClient imageclientset.ImageV1Interface, jobSpec *JobSpec) api.Step {
 	return &promotionStep{
 		config:    config,


### PR DESCRIPTION
If name or tag is set, no defaulting is performed, but otherwise default
the base values. Allows additional_tags to be specified when no other
fields are set.