### PR TITLE
Don't write a file into the working dir during clone

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -94,7 +94,7 @@ func (s *sourceStep) Run(ctx context.Context, dry bool) error {
 	refs.PathAlias = s.config.PathAlias
 	optionsSpec := map[string]interface{}{
 		"src_root":       "/go",
-		"log":            "-",
+		"log":            "/dev/null",
 		"git_user_name":  "ci-robot",
 		"git_user_email": "ci-robot@openshift.io",
 		"refs":           []interface{}{refs},


### PR DESCRIPTION
Log `-` was interpreted as `file in the current directory` which caused
the git repo to be dirty. Use `/dev/null` instead