### PR TITLE
Spread RPM server over two servers to ensure availability

### DIFF
--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -83,7 +83,7 @@ func (s *rpmServerStep) Run(ctx context.Context, dry bool) error {
 	deploymentConfig := &appsapi.DeploymentConfig{
 		ObjectMeta: commonMeta,
 		Spec: appsapi.DeploymentConfigSpec{
-			Replicas: 1,
+			Replicas: 2,
 			Selector: labelSet,
 			Template: &coreapi.PodTemplateSpec{
 				ObjectMeta: meta.ObjectMeta{


### PR DESCRIPTION
When autoscaling is present, RPM could be disrupted. We want to ensure
it's available.