### PR TITLE
Increase namespace default teardown to 1 hour

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -195,7 +195,7 @@ type options struct {
 
 func bindOptions(flag *flag.FlagSet) *options {
 	opt := &options{
-		idleCleanupDuration: time.Duration(10 * time.Minute),
+		idleCleanupDuration: time.Duration(1 * time.Hour),
 	}
 
 	// command specific options


### PR DESCRIPTION
Debugging when issues occur is painful, and 1 hour gives people time to
react to see why the issue occurred. It may slightly increase resource
use.