### PR TITLE
When importing images from the same cluster, use refs

### DIFF
--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -152,6 +152,10 @@ func (s *inputImageTagStep) Description() string {
 }
 
 func InputImageTagStep(config api.InputImageTagStepConfiguration, srcClient, dstClient imageclientset.ImageV1Interface, jobSpec *JobSpec) api.Step {
+	// when source and destination are the same, we don't need to use external imports
+	if srcClient == dstClient {
+		config.BaseImage.Cluster = ""
+	}
 	return &inputImageTagStep{
 		config:    config,
 		srcClient: srcClient,

--- a/pkg/steps/release_images.go
+++ b/pkg/steps/release_images.go
@@ -312,6 +312,10 @@ func (s *releaseImagesTagStep) Description() string {
 }
 
 func ReleaseImagesTagStep(config api.ReleaseTagConfiguration, srcClient, dstClient imageclientset.ImageV1Interface, routeClient routeclientset.RoutesGetter, configMapClient coreclientset.ConfigMapsGetter, params *DeferredParameters, jobSpec *JobSpec) api.Step {
+	// when source and destination are the same, we don't need to use external imports
+	if srcClient == dstClient {
+		config.Cluster = ""
+	}
 	return &releaseImagesTagStep{
 		config:          config,
 		srcClient:       srcClient,


### PR DESCRIPTION
As image stream sizes get larger, it can take longer to import. When we
are importing from the same cluster use image stream image references
rather than forcing an import.