### PR TITLE
Make -h and --help behave equally

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -131,6 +131,7 @@ func main() {
 	}
 	if opt.help {
 		fmt.Printf(usage)
+		flagSet.SetOutput(os.Stdout)
 		flagSet.Usage()
 		os.Exit(0)
 	}
@@ -199,7 +200,8 @@ func bindOptions(flag *flag.FlagSet) *options {
 	}
 
 	// command specific options
-	flag.BoolVar(&opt.help, "h", false, "See help for this command.")
+	flag.BoolVar(&opt.help, "h", false, "short for --help")
+	flag.BoolVar(&opt.help, "help", false, "See help for this command.")
 	flag.BoolVar(&opt.verbose, "v", false, "Show verbose output.")
 
 	// what we will run


### PR DESCRIPTION
/cc @droslean @petr-muller @stevekuznetsov

Currently:

`-h`

<details>

```
Orchestrate multi-stage image-based builds

The ci-operator reads a declarative configuration JSON file and executes a set of build
steps on an OpenShift cluster for image-based components. By default, all steps are run,
but a caller may select one or more targets (image names or test names) to limit to only
steps that those targets depend on. The build creates a new project to run the builds in
and can automatically clean up the project when the build completes.

ci-operator leverages declarative OpenShift builds and images to reuse previously compiled
artifacts. It makes building multiple images that share one or more common base layers
simple as well as running tests that depend on those images.

Since the command is intended for use in CI environments it requires an input environment
variable called the JOB_SPEC that defines the GitHub project to execute and the commit,
branch, and any PRs to merge onto the branch. See the kubernetes/test-infra project for
a description of JOB_SPEC.

The inputs of the build (source code, tagged images, configuration) are combined to form
a consistent name for the target namespace that will change if any of the inputs change.
This allows multiple test jobs to share common artifacts and still perform retries.

The standard build steps are designed for simple command-line actions (like invoking
"make test") but can be extended by passing one or more templates via the --template flag.
The name of the template defines the stage and the template must contain at least one
pod. The parameters passed to the template are the current process environment and a set
of dynamic parameters that are inferred from previous steps. These parameters are:

  NAMESPACE
    The namespace generated by the operator for the given inputs or the value of
    --namespace.

  IMAGE_FORMAT
    A string that points to the public image repository URL of the image stream(s)
    created by the tag step. Example:

      registry.svc.ci.openshift.org/ci-op-9o8bacu/stable:${component}

    Will cause the template to depend on all image builds.

  IMAGE_<component>
    The public image repository URL for an output image. If specified the template
    will depend on the image being built.

  LOCAL_IMAGE_<component>
    The public image repository URL for an image that was built during this run but
    was not part of the output (such as pipeline cache images). If specified the
    template will depend on the image being built.

  JOB_NAME
    The job name from the JOB_SPEC

  JOB_NAME_SAFE
    The job name in a form safe for use as a Kubernetes resource name.

  JOB_NAME_HASH
    A short hash of the job name for making tasks unique.

  RPM_REPO
    If the job creates RPMs this will be the public URL that can be used as the
    baseurl= value of an RPM repository.

Dynamic environment variables are overriden by process environment variables.

Both test and template jobs can gather artifacts created by pods. Set
--artifact-dir to define the top level artifact directory, and any test task
that defines artifact_dir or template that has an "artifacts" volume mounted
into a container will have artifacts extracted after the container has completed.
Errors in artifact extraction will not cause build failures.

In CI environments the inputs to a job may be different than what a normal
development workflow would use. The --override file will override fields
defined in the config file, such as base images and the release tag configuration.

After a successful build the --promote will tag each built image (in "images")
to the image stream(s) identified by the "promotion" config, which defaults to
the same image stream as the release configuration. You may add additional 
images to promote and their target names via the "additional_images" map.
Usage:
  -artifact-dir string
    	If set grab artifacts from test and template jobs.
  -base-namespace string
    	Namespace to read builds from, defaults to stable. (default "stable")
  -config string
    	The configuration file. If not specified the CONFIG_SPEC environment variable will be used.
  -delete-when-idle duration
    	If no pod is running for longer than this interval, delete the namespace. Set to zero to retain the contents. (default 1h0m0s)
  -dry-run
    	Print the steps that would be run and the objects that would be created without executing any steps
  -git-ref string
    	Populate the job spec from this local Git reference. If JOB_SPEC is set, the refs field will be overwritten.
  -h	See help for this command.
  -namespace string
    	Namespace to create builds into, defaults to build_id from JOB_SPEC. If the string '{id}' is in this value it will be replaced with the build input hash.
  -override string
    	A configuration file that can override fields defined in the input part of the configuration.
  -promote
    	When all other targets complete, publish the set of images built by this job into the release configuration.
  -secret-dir value
    	One or more directories that should converted into secrets in the test namespace.
  -target value
    	One or more targets in the configuration to build. Only steps that are required for this target will be run.
  -template value
    	A set of paths to optional templates to add as stages to this job. Each template is expected to contain at least one restart=Never pod. Parameters are filled from environment or from the automatic parameters generated by the operator.
  -v	Show verbose output.
  -write-params string
    	If set write an env-compatible file with the output of the job.
```
</details>

`--help`

<details>

```
Usage:
  -artifact-dir string
    	If set grab artifacts from test and template jobs.
  -base-namespace string
    	Namespace to read builds from, defaults to stable. (default "stable")
  -config string
    	The configuration file. If not specified the CONFIG_SPEC environment variable will be used.
  -delete-when-idle duration
    	If no pod is running for longer than this interval, delete the namespace. Set to zero to retain the contents. (default 1h0m0s)
  -dry-run
    	Print the steps that would be run and the objects that would be created without executing any steps
  -git-ref string
    	Populate the job spec from this local Git reference. If JOB_SPEC is set, the refs field will be overwritten.
  -h	See help for this command.
  -namespace string
    	Namespace to create builds into, defaults to build_id from JOB_SPEC. If the string '{id}' is in this value it will be replaced with the build input hash.
  -override string
    	A configuration file that can override fields defined in the input part of the configuration.
  -promote
    	When all other targets complete, publish the set of images built by this job into the release configuration.
  -secret-dir value
    	One or more directories that should converted into secrets in the test namespace.
  -target value
    	One or more targets in the configuration to build. Only steps that are required for this target will be run.
  -template value
    	A set of paths to optional templates to add as stages to this job. Each template is expected to contain at least one restart=Never pod. Parameters are filled from environment or from the automatic parameters generated by the operator.
  -v	Show verbose output.
  -write-params string
    	If set write an env-compatible file with the output of the job.
```

</details>