### PR TITLE
Remove decoration in the prow job config example.

### DIFF
--- a/ONBOARD.md
+++ b/ONBOARD.md
@@ -174,8 +174,6 @@ presubmits:
     rerun_command: "/test unit"
     always_run: true
     trigger: "((?m)^/test( all| unit),?(\\s+|$))"
-    decorate: true
-    skip_cloning: true
     spec:
       serviceAccountName: ci-operator
       containers:


### PR DESCRIPTION
Since the documentation is not focusing on explaining further the prow jobs, the decoration configuration in the prow job example is not needed.