### PR TITLE
Label all pods we create with the ProwJobID for artifacts

### DIFF
--- a/pkg/steps/job_spec.go
+++ b/pkg/steps/job_spec.go
@@ -16,9 +16,10 @@ import (
 // we do not import it as importing test-infra is a
 // massive hassle.
 type JobSpec struct {
-	Type    ProwJobType `json:"type,omitempty"`
-	Job     string      `json:"job,omitempty"`
-	BuildId string      `json:"buildid,omitempty"`
+	Type      ProwJobType `json:"type,omitempty"`
+	Job       string      `json:"job,omitempty"`
+	BuildId   string      `json:"buildid,omitempty"`
+	ProwJobID string      `json:"prowjobid,omitempty"`
 
 	Refs Refs `json:"refs,omitempty"`
 

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -61,6 +61,7 @@ func (s *rpmServerStep) Run(ctx context.Context, dry bool) error {
 		PersistsLabel:    "true",
 		JobLabel:         s.jobSpec.Job,
 		BuildIdLabel:     s.jobSpec.BuildId,
+		ProwJobIdLabel:   s.jobSpec.ProwJobID,
 		CreatedByCILabel: "true",
 		AppLabel:         RPMRepoName,
 	}

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -29,6 +29,8 @@ const (
 	BuildIdLabel       = "build-id"
 	CreatesLabel       = "creates"
 	CreatedByCILabel   = "created-by-ci"
+
+	ProwJobIdLabel = "prow.k8s.io/id"
 )
 
 var (
@@ -136,6 +138,7 @@ func buildFromSource(jobSpec *JobSpec, fromTag, toTag api.PipelineImageStreamTag
 				PersistsLabel:    "false",
 				JobLabel:         jobSpec.Job,
 				BuildIdLabel:     jobSpec.BuildId,
+				ProwJobIdLabel:   jobSpec.ProwJobID,
 				CreatesLabel:     string(toTag),
 				CreatedByCILabel: "true",
 			},
@@ -151,11 +154,11 @@ func buildFromSource(jobSpec *JobSpec, fromTag, toTag api.PipelineImageStreamTag
 				Strategy: buildapi.BuildStrategy{
 					Type: buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{
-						DockerfilePath: dockerfilePath,
-						From:           from,
-						ForcePull:      true,
-						NoCache:        true,
-						Env:            []coreapi.EnvVar{},
+						DockerfilePath:          dockerfilePath,
+						From:                    from,
+						ForcePull:               true,
+						NoCache:                 true,
+						Env:                     []coreapi.EnvVar{},
 						ImageOptimizationPolicy: &layer,
 					},
 				},

--- a/pkg/steps/test.go
+++ b/pkg/steps/test.go
@@ -40,6 +40,16 @@ func (s *testStep) Run(ctx context.Context, dry bool) error {
 	pod := &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Name: s.config.As,
+			Labels: map[string]string{
+				PersistsLabel:    "false",
+				JobLabel:         s.jobSpec.Job,
+				BuildIdLabel:     s.jobSpec.BuildId,
+				ProwJobIdLabel:   s.jobSpec.ProwJobID,
+				CreatedByCILabel: "true",
+			},
+			Annotations: map[string]string{
+				JobSpecAnnotation: s.jobSpec.rawSpec,
+			},
 		},
 		Spec: coreapi.PodSpec{
 			RestartPolicy: coreapi.RestartPolicyNever,


### PR DESCRIPTION
Our artifact gathering and pushing controller will push logs from
containers that terminate in Pods labeled with a ProwJobID. We need to
label our test with this so that we can get more logs pushed.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @bbguimaraes @petr-muller @droslean @smarterclayton 