### PR TITLE
Warn instead of fail when user doesn't have namespace update permission

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -596,6 +596,10 @@ func (o *options) initializeNamespace() error {
 			}
 
 			_, updateErr := client.Namespaces().Update(ns)
+			if kerrors.IsForbidden(updateErr) {
+				log.Printf("warning: Could not mark the namespace to be deleted later because you do not have permission to update the namespace (details: %v)", updateErr)
+				return nil
+			}
 			return updateErr
 		}); err != nil {
 			return fmt.Errorf("could not update namespace to add TTLs: %v", err)


### PR DESCRIPTION
```
2018/08/14 14:29:36 warning: Could not mark the namespace to be deleted later because you do not have permission to update the namespace (details: namespaces "ci-op-kr3t77r0" is forbidden: User "smarterclayton" cannot update namespaces in the namespace "ci-op-kr3t77r0": no RBAC policy matched)
```

Also, print the pull spec during output:

```
2018/08/14 14:29:36 Stable images will be pullable from registry.svc.ci.openshift.org/ci-op-kr3t77r0/stable:${component}
```