### PR TITLE
Allow release tag configuration to be omitted for unrelated repos

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -63,7 +63,7 @@ type ReleaseBuildConfiguration struct {
 	// Resources is a set of resource requests or limits over the
 	// input types. The special name '*' may be used to set default
 	// requests and limits.
-	Resources ResourceConfiguration
+	Resources ResourceConfiguration `json:"resources,omitempty"`
 }
 
 // ResourceConfiguration defines resource overrides for jobs run

--- a/pkg/steps/build_defaults.go
+++ b/pkg/steps/build_defaults.go
@@ -363,24 +363,26 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *JobSpec
 	for i := range config.Images {
 		image := &config.Images[i]
 		buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
-		if config.ReleaseTagConfiguration != nil && len(config.ReleaseTagConfiguration.Name) > 0 {
-			buildSteps = append(buildSteps, api.StepConfiguration{OutputImageTagStepConfiguration: &api.OutputImageTagStepConfiguration{
-				From: image.To,
-				To: api.ImageStreamTagReference{
-					Name: fmt.Sprintf("%s%s", config.ReleaseTagConfiguration.NamePrefix, StableImageStream),
-					Tag:  string(image.To),
-				},
-				Optional: image.Optional,
-			}})
-		} else {
-			buildSteps = append(buildSteps, api.StepConfiguration{OutputImageTagStepConfiguration: &api.OutputImageTagStepConfiguration{
-				From: image.To,
-				To: api.ImageStreamTagReference{
-					Name: string(image.To),
-					Tag:  "ci",
-				},
-				Optional: image.Optional,
-			}})
+		if config.ReleaseTagConfiguration != nil {
+			if len(config.ReleaseTagConfiguration.Name) > 0 {
+				buildSteps = append(buildSteps, api.StepConfiguration{OutputImageTagStepConfiguration: &api.OutputImageTagStepConfiguration{
+					From: image.To,
+					To: api.ImageStreamTagReference{
+						Name: fmt.Sprintf("%s%s", config.ReleaseTagConfiguration.NamePrefix, StableImageStream),
+						Tag:  string(image.To),
+					},
+					Optional: image.Optional,
+				}})
+			} else {
+				buildSteps = append(buildSteps, api.StepConfiguration{OutputImageTagStepConfiguration: &api.OutputImageTagStepConfiguration{
+					From: image.To,
+					To: api.ImageStreamTagReference{
+						Name: string(image.To),
+						Tag:  "ci",
+					},
+					Optional: image.Optional,
+				}})
+			}
 		}
 	}
 


### PR DESCRIPTION
ci-operator can be used without an opinionated release configuration (like origin)
and instead be used in "single project" mode. null release config should mean
"don't use output image or create stable"

Allows us to fix ci-operator.