### PR TITLE
Events should not be logged

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -852,7 +852,6 @@ func shorten(value string, l int) string {
 
 func eventRecorder(kubeClient *coreclientset.CoreV1Client, namespace string) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(log.Printf)
 	eventBroadcaster.StartRecordingToSink(&coreclientset.EventSinkImpl{
 		Interface: coreclientset.New(kubeClient.RESTClient()).Events("")})
 	return eventBroadcaster.NewRecorder(


### PR DESCRIPTION
```
2018/08/30 04:40:50 Tagging openshift/release:golang-1.9 into pipeline:root
2018/08/30 04:40:50 Tagging openshift/origin-v3.11:base into pipeline:base-without-rpms
2018/08/30 04:40:50 Event(v1.ObjectReference{Kind:"", Namespace:"ci-op-397xvch6", Name:"", UID:"", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'CiJobStarted' Running job branch-ci-kubernetes-cluster-capacity-images-release-3.11 for PRs () in namespace ci-op-397xvch6 from authors ()
2018/08/30 04:40:50 Tagged release images from openshift/origin-v3.11:${component}, images will be pullable from registry.svc.ci.openshift.org/ci-op-397xvch6/stable:${component}
```

should be

```
2018/08/30 04:40:50 Tagging openshift/release:golang-1.9 into pipeline:root
2018/08/30 04:40:50 Tagging openshift/origin-v3.11:base into pipeline:base-without-rpms
2018/08/30 04:40:50 Tagged release images from openshift/origin-v3.11:${component}, images will be pullable from registry.svc.ci.openshift.org/ci-op-397xvch6/stable:${component}
```