### PR TITLE
Add a prototype release creation step

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -104,6 +104,31 @@ func (l *internalImageLink) Matches(other StepLink) bool {
 	}
 }
 
+func ReleasePayloadImageLink(ref PipelineImageStreamTagReference) StepLink {
+	return &releasePayloadImageLink{image: ref}
+}
+
+type releasePayloadImageLink struct {
+	image PipelineImageStreamTagReference
+}
+
+func (l *releasePayloadImageLink) Same(other StepLink) bool {
+	o, ok := other.(*releasePayloadImageLink)
+	if !ok {
+		return false
+	}
+	return o.image == l.image
+}
+
+func (l *releasePayloadImageLink) Matches(other StepLink) bool {
+	switch link := other.(type) {
+	case *releasePayloadImageLink:
+		return l.image == link.image
+	default:
+		return false
+	}
+}
+
 func ImagesReadyLink() StepLink {
 	return &imagesReadyLink{}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/ci-operator/pkg/api"
 	"github.com/openshift/ci-operator/pkg/steps"
+	"github.com/openshift/ci-operator/pkg/steps/release"
 )
 
 // FromConfig interprets the human-friendly fields in
@@ -154,7 +155,9 @@ func FromConfig(
 		buildSteps = append(buildSteps, steps.WriteParametersStep(params, paramFile, jobSpec))
 	}
 
-	if !hasReleaseConfiguration {
+	if hasReleaseConfiguration {
+		buildSteps = append(buildSteps, release.AssembleReleaseStep(*config.ReleaseTagConfiguration, podClient, imageClient, artifactDir, jobSpec))
+	} else {
 		buildSteps = append(buildSteps, steps.StableImagesTagStep(imageClient, jobSpec))
 	}
 

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -1,0 +1,162 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	imageapi "github.com/openshift/api/image/v1"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rbacclientset "k8s.io/client-go/kubernetes/typed/rbac/v1"
+
+	"github.com/openshift/ci-operator/pkg/api"
+	"github.com/openshift/ci-operator/pkg/steps"
+)
+
+// assembleReleaseStep knows how to build an update payload image for
+// an OpenShift release by waiting for the full release image set to be
+// created, then invoking the admin command for building a new release.
+type assembleReleaseStep struct {
+	config      api.ReleaseTagConfiguration
+	imageClient imageclientset.ImageV1Interface
+	podClient   steps.PodClient
+	rbacClient  rbacclientset.RbacV1Interface
+	artifactDir string
+	jobSpec     *api.JobSpec
+}
+
+func (s *assembleReleaseStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
+	return nil, nil
+}
+
+func (s *assembleReleaseStep) Run(ctx context.Context, dry bool) error {
+	stable, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(api.StableImageStream, meta.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("could not resolve stable imagestream: %v", err)
+	}
+	cvo, ok := resolvePullSpec(stable, "cluster-version-operator")
+	if !ok {
+		log.Printf("No release image necessary, stable image stream does not include a cluster-version-operator image")
+		return nil
+	}
+	if _, ok := resolvePullSpec(stable, "cli"); !ok {
+		return fmt.Errorf("no 'cli' image was tagged into the stable stream, that image is required for building a release")
+	}
+
+	release, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Create(&imageapi.ImageStream{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "release",
+		},
+	})
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+		release, err = s.imageClient.ImageStreams(s.jobSpec.Namespace).Get("release", meta.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	destination := fmt.Sprintf("%s:%s", release.Status.PublicDockerImageRepository, "latest")
+	log.Printf("Create a new update payload image %s", destination)
+	podConfig := steps.PodStepConfiguration{
+		As: "release-latest",
+		From: api.ImageStreamTagReference{
+			Name: api.StableImageStream,
+			Tag:  "cli",
+		},
+		ServiceAccountName: "builder",
+		ArtifactDir:        "/tmp/artifacts",
+		Commands: fmt.Sprintf(`
+set -euo pipefail
+export HOME=/tmp
+oc registry login
+oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q
+oc adm release extract --from=%q --to=/tmp/artifacts/release-payload
+`, s.jobSpec.Namespace, api.StableImageStream, cvo, destination, destination),
+	}
+	step := steps.PodStep("release", podConfig, api.ResourceConfiguration{}, s.podClient, s.artifactDir, s.jobSpec)
+
+	return step.Run(ctx, dry)
+}
+
+func (s *assembleReleaseStep) Done() (bool, error) {
+	// TODO: define done
+	return true, nil
+}
+
+func (s *assembleReleaseStep) Requires() []api.StepLink {
+	return []api.StepLink{api.ImagesReadyLink()}
+}
+
+func (s *assembleReleaseStep) Creates() []api.StepLink {
+	return []api.StepLink{api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference("latest"))}
+}
+
+func (s *assembleReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
+	return api.ParameterMap{
+		"RELEASE_IMAGE_LATEST": func() (string, error) {
+			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get("release", meta.GetOptions{})
+			if err != nil {
+				return "", fmt.Errorf("could not retrieve output imagestream: %v", err)
+			}
+			var registry string
+			if len(is.Status.PublicDockerImageRepository) > 0 {
+				registry = is.Status.PublicDockerImageRepository
+			} else if len(is.Status.DockerImageRepository) > 0 {
+				registry = is.Status.DockerImageRepository
+			} else {
+				return "", fmt.Errorf("image stream %s has no accessible image registry value", "release")
+			}
+			return fmt.Sprintf("%s:%s", registry, "latest"), nil
+		},
+	}, api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference("latest"))
+}
+
+func (s *assembleReleaseStep) Name() string { return "[release:latest]" }
+
+func (s *assembleReleaseStep) Description() string {
+	return fmt.Sprintf("Create a release image in the release image stream")
+}
+
+// AssembleReleaseStep builds a new update payload image based on the cluster version operator
+// and the operators defined in the release configuration.
+func AssembleReleaseStep(config api.ReleaseTagConfiguration, podClient steps.PodClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec) api.Step {
+	return &assembleReleaseStep{
+		config:      config,
+		podClient:   podClient,
+		imageClient: imageClient,
+		artifactDir: artifactDir,
+		jobSpec:     jobSpec,
+	}
+}
+
+func resolvePullSpec(is *imageapi.ImageStream, tag string) (string, bool) {
+	for _, tags := range is.Status.Tags {
+		if tags.Tag != tag {
+			continue
+		}
+		if len(tags.Items) == 0 {
+			break
+		}
+		if image := tags.Items[0].Image; len(image) > 0 {
+			if len(is.Status.PublicDockerImageRepository) > 0 {
+				return fmt.Sprintf("%s@%s", is.Status.PublicDockerImageRepository, image), true
+			}
+			if len(is.Status.DockerImageRepository) > 0 {
+				return fmt.Sprintf("%s@%s", is.Status.DockerImageRepository, image), true
+			}
+		}
+		break
+	}
+	if len(is.Status.PublicDockerImageRepository) > 0 {
+		return fmt.Sprintf("%s:%s", is.Status.PublicDockerImageRepository, tag), true
+	}
+	if len(is.Status.DockerImageRepository) > 0 {
+		return fmt.Sprintf("%s:%s", is.Status.DockerImageRepository, tag), true
+	}
+	return "", false
+}

--- a/pkg/steps/release_images.go
+++ b/pkg/steps/release_images.go
@@ -43,6 +43,11 @@ func (s *stableImagesTagStep) Run(ctx context.Context, dry bool) error {
 		ObjectMeta: meta.ObjectMeta{
 			Name: api.StableImageStream,
 		},
+		Spec: imageapi.ImageStreamSpec{
+			LookupPolicy: imageapi.ImageLookupPolicy{
+				Local: true,
+			},
+		},
 	}
 	if dry {
 		istJSON, err := json.MarshalIndent(newIS, "", "  ")
@@ -164,6 +169,11 @@ func (s *releaseImagesTagStep) Run(ctx context.Context, dry bool) error {
 		newIS := &imageapi.ImageStream{
 			ObjectMeta: meta.ObjectMeta{
 				Name: api.StableImageStream,
+			},
+			Spec: imageapi.ImageStreamSpec{
+				LookupPolicy: imageapi.ImageLookupPolicy{
+					Local: true,
+				},
 			},
 		}
 		for _, tag := range is.Spec.Tags {

--- a/pkg/steps/test.go
+++ b/pkg/steps/test.go
@@ -16,8 +16,17 @@ import (
 	"github.com/openshift/ci-operator/pkg/api"
 )
 
-type testStep struct {
-	config      api.TestStepConfiguration
+type PodStepConfiguration struct {
+	As                 string
+	From               api.ImageStreamTagReference
+	Commands           string
+	ArtifactDir        string
+	ServiceAccountName string
+}
+
+type podStep struct {
+	name        string
+	config      PodStepConfiguration
 	resources   api.ResourceConfiguration
 	podClient   PodClient
 	istClient   imageclientset.ImageStreamTagsGetter
@@ -25,17 +34,22 @@ type testStep struct {
 	jobSpec     *api.JobSpec
 }
 
-func (s *testStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
+func (s *podStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
 	return nil, nil
 }
 
-func (s *testStep) Run(ctx context.Context, dry bool) error {
-	log.Printf("Executing test %s", s.config.As)
+func (s *podStep) Run(ctx context.Context, dry bool) error {
+	log.Printf("Executing %s %s", s.name, s.config.As)
 
 	containerResources, err := resourcesFor(s.resources.RequirementsForStep(s.config.As))
 	if err != nil {
-		return fmt.Errorf("unable to calculate test pod resources for %s: %s", s.config.As, err)
+		return fmt.Errorf("unable to calculate %s pod resources for %s: %s", s.name, s.config.As, err)
 	}
+
+	if len(s.config.From.Namespace) > 0 {
+		return fmt.Errorf("pod step does not supported an image stream tag reference outside the namespace")
+	}
+	image := fmt.Sprintf("%s:%s", s.config.From.Name, s.config.From.Tag)
 
 	pod := &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
@@ -52,11 +66,12 @@ func (s *testStep) Run(ctx context.Context, dry bool) error {
 			},
 		},
 		Spec: coreapi.PodSpec{
-			RestartPolicy: coreapi.RestartPolicyNever,
+			ServiceAccountName: s.config.ServiceAccountName,
+			RestartPolicy:      coreapi.RestartPolicyNever,
 			Containers: []coreapi.Container{
 				{
-					Name:                     "test",
-					Image:                    fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From),
+					Name:                     s.name,
+					Image:                    image,
 					Command:                  []string{"/bin/sh", "-c", "#!/bin/sh\nset -eu\n" + s.config.Commands},
 					Resources:                containerResources,
 					TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
@@ -74,7 +89,7 @@ func (s *testStep) Run(ctx context.Context, dry bool) error {
 			MountPath: s.config.ArtifactDir,
 		})
 		addArtifactsContainer(pod, s.config.ArtifactDir)
-		artifacts.CollectFromPod(pod.Name, []string{"test"}, nil)
+		artifacts.CollectFromPod(pod.Name, []string{s.name}, nil)
 		notifier = artifacts
 	}
 
@@ -91,32 +106,32 @@ func (s *testStep) Run(ctx context.Context, dry bool) error {
 	go func() {
 		<-ctx.Done()
 		notifier.Cancel()
-		log.Printf("cleanup: Deleting test pod %s", s.config.As)
+		log.Printf("cleanup: Deleting %s pod %s", s.name, s.config.As)
 		if err := s.podClient.Pods(s.jobSpec.Namespace).Delete(s.config.As, nil); err != nil && !errors.IsNotFound(err) {
-			log.Printf("error: Could not delete test pod: %v", err)
+			log.Printf("error: Could not delete %s pod: %v", s.name, err)
 		}
 	}()
 
 	pod, err = createOrRestartPod(s.podClient.Pods(s.jobSpec.Namespace), pod)
 	if err != nil {
-		return fmt.Errorf("failed to create or restart test pod: %v", err)
+		return fmt.Errorf("failed to create or restart %s pod: %v", s.name, err)
 	}
 
 	if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, notifier); err != nil {
-		return fmt.Errorf("failed to wait for test pod to complete: %v", err)
+		return fmt.Errorf("failed to wait for %s pod to complete: %v", s.name, err)
 	}
 
 	return nil
 }
 
-func (s *testStep) gatherArtifacts() bool {
+func (s *podStep) gatherArtifacts() bool {
 	return len(s.config.ArtifactDir) > 0 && len(s.artifactDir) > 0
 }
 
-func (s *testStep) Done() (bool, error) {
+func (s *podStep) Done() (bool, error) {
 	ready, err := isPodCompleted(s.podClient.Pods(s.jobSpec.Namespace), s.config.As)
 	if err != nil {
-		return false, fmt.Errorf("failed to determine if test pod was completed: %v", err)
+		return false, fmt.Errorf("failed to determine if %s pod was completed: %v", s.name, err)
 	}
 	if !ready {
 		return false, nil
@@ -124,26 +139,46 @@ func (s *testStep) Done() (bool, error) {
 	return true, nil
 }
 
-func (s *testStep) Requires() []api.StepLink {
-	return []api.StepLink{api.InternalImageLink(s.config.From)}
+func (s *podStep) Requires() []api.StepLink {
+	if s.config.From.Name == api.PipelineImageStream {
+		return []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReference(s.config.From.Tag))}
+	}
+	return []api.StepLink{api.ImagesReadyLink()}
 }
 
-func (s *testStep) Creates() []api.StepLink {
+func (s *podStep) Creates() []api.StepLink {
 	return []api.StepLink{}
 }
 
-func (s *testStep) Provides() (api.ParameterMap, api.StepLink) {
+func (s *podStep) Provides() (api.ParameterMap, api.StepLink) {
 	return nil, nil
 }
 
-func (s *testStep) Name() string { return s.config.As }
+func (s *podStep) Name() string { return s.config.As }
 
-func (s *testStep) Description() string {
+func (s *podStep) Description() string {
 	return fmt.Sprintf("Run the tests for %s in a pod and wait for success or failure", s.config.As)
 }
 
 func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, artifactDir string, jobSpec *api.JobSpec) api.Step {
-	return &testStep{
+	return PodStep(
+		"test",
+		PodStepConfiguration{
+			As:          config.As,
+			From:        api.ImageStreamTagReference{Name: api.PipelineImageStream, Tag: string(config.From)},
+			Commands:    config.Commands,
+			ArtifactDir: config.ArtifactDir,
+		},
+		resources,
+		podClient,
+		artifactDir,
+		jobSpec,
+	)
+}
+
+func PodStep(name string, config PodStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, artifactDir string, jobSpec *api.JobSpec) api.Step {
+	return &podStep{
+		name:        name,
 		config:      config,
 		resources:   resources,
 		podClient:   podClient,


### PR DESCRIPTION
The step reuses the pod test logic (factored out) to run a cli command
to craft a new release from the latest stable stream in a PR. The release
payload is published to "release:latest" in the image stream. The step
is always run as long as there is a release tag specification. The step
does nothing if no image "cluster-version-operator" is present in the stable
image stream.

Templates can reference this via `RELEASE_IMAGE_LATEST`.  It is currently an optional target and only a few jobs will directly target it.

Design doc: https://docs.google.com/document/d/1CGZVEyuloZ9oD4NUArW6dnEpi0WFc6BP2tqPSwFZTCY/edit#heading=h.1zgrwxmpgxbr