### PR TITLE
Use headings for env in doc so they're linkable

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -20,66 +20,65 @@ A number of parameters are available to the `Template` and will be provided if
 the `Template` is explicitly configured to consume them. The following parameters
 will be provided to `Template`s:
 
- - `NAMESPACE`
-   The namespace in which your `Template` is processed. Target this namespace with
-   your objects.
+#### `NAMESPACE`
+The namespace in which your `Template` is processed. Target this namespace with
+your objects.
 
-   | Example: | `ci-op-<input-hash>` |
-   | - | - |
+| Example: | `ci-op-<input-hash>` |
+| - | - |
 
- - `IMAGE_FORMAT`
-   The image repository URL template using which your job's release images can
-   be pulled, formatted for the OpenShift Ansible `-e oreg_url` parameter.
-   `Template`s depending on this parameter will be processed only after all
-   images are built.
+#### `IMAGE_FORMAT`
+The image repository URL template using which your job's release images can
+be pulled, formatted for the OpenShift Ansible `-e oreg_url` parameter.
+`Template`s depending on this parameter will be processed only after all
+images are built.
 
-   | Example: | `registry.svc.ci.openshift.org/ci-op-<input-hash>/stable:${component}` |
-   | - | - |
+| Example: | `registry.svc.ci.openshift.org/ci-op-<input-hash>/stable:${component}` |
+| - | - |
 
+#### `RPM_REPO`
+The RPM repository URL from which your job's RPMs can be installed.
+`Template`s depending on this parameter will be processed only after the
+`rpm` image is built.
 
- - `RPM_REPO`
-   The RPM repository URL from which your job's RPMs can be installed.
-   `Template`s depending on this parameter will be processed only after the
-   `rpm` image is built.
+| Example: | `http://rpm-repo-ci-op-<input-hash>.svc.ci.openshift.org` |
+| - | - |
 
-   | Example: | `http://rpm-repo-ci-op-<input-hash>.svc.ci.openshift.org` |
-   | - | - |
+#### `IMAGE_<component>`
+The image repository URL from which the `<component>` image can be pulled.
+If a component name has hyphens, replace them with underscores. For instance,
+the `$IMAGE_SOME_NAME` parameter would point to the registry URL for `some-name`.
+Valid `<component>` images are any non-optional images defined in the `images`
+array. Many parameters of this format can be provided for one `Template`.
+`Template`s depending on these parameters will be processed only after the
+`<component>` images are built.
 
- - `IMAGE_<component>`
-   The image repository URL from which the `<component>` image can be pulled.
-   If a component name has hyphens, replace them with underscores. For instance,
-   the `$IMAGE_SOME_NAME` parameter would point to the registry URL for `some-name`.
-   Valid `<component>` images are any non-optional images defined in the `images`
-   array. Many parameters of this format can be provided for one `Template`.
-   `Template`s depending on these parameters will be processed only after the
-   `<component>` images are built.
+| Example: | `registry.svc.ci.openshift.org/ci-op-<input-hash>/stable:<component>` |
+| - | - |
 
-   | Example: | `registry.svc.ci.openshift.org/ci-op-<input-hash>/stable:<component>` |
-   | - | - |
+#### `LOCAL_IMAGE_<pipeline-tag>`
+The image repository URL from which the `<pipeline-tag>` image can be pulled.
+If a component name has hyphens, replace them with underscores. For instance,
+the `$LOCAL_IMAGE_SOME_NAME` parameter would point to the registry URL for
+`some-name`. Valid `<pipeline-tag>` images are `src`, `bin`, `test-bin`, or
+`rpms`. Many parameters of this format can be provided for one `Template`.
+`Template`s depending on these parameters will be processed only after the
+`<pipeline-tag>` images are built.
 
- - `LOCAL_IMAGE_<pipeline-tag>`
-   The image repository URL from which the `<pipeline-tag>` image can be pulled.
-   If a component name has hyphens, replace them with underscores. For instance,
-   the `$LOCAL_IMAGE_SOME_NAME` parameter would point to the registry URL for
-   `some-name`. Valid `<pipeline-tag>` images are `src`, `bin`, `test-bin`, or
-   `rpms`. Many parameters of this format can be provided for one `Template`.
-   `Template`s depending on these parameters will be processed only after the
-   `<pipeline-tag>` images are built.
+| Example: | `registry.svc.ci.openshift.org/ci-op-<input-hash>/pipeline:<pipeline-tag>` |
+| - | - |
 
-   | Example: | `registry.svc.ci.openshift.org/ci-op-<input-hash>/pipeline:<pipeline-tag>` |
-   | - | - |
+#### `JOB_NAME`
+The job name as provided by Prow in the `$JOB_SPEC`.
 
- - `JOB_NAME`
-   The job name as provided by Prow in the `$JOB_SPEC`.
+#### `JOB_NAME_SAFE`
+The `$JOB_NAME` transformed to be a valid Kubernetes object identifier.
 
- - `JOB_NAME_SAFE`
-   The `$JOB_NAME` transformed to be a valid Kubernetes object identifier.
-
- - `JOB_NAME_HASH`
-   A short hash of the `$JOB_NAME`. Append this to the `$NAMESPACE` to create an
-   identifier that is unique across all jobs for the same inputs. Note that this
-   identifier will not be unique across multiple builds of the same job for the
-   same inputs.
+#### `JOB_NAME_HASH`
+A short hash of the `$JOB_NAME`. Append this to the `$NAMESPACE` to create an
+identifier that is unique across all jobs for the same inputs. Note that this
+identifier will not be unique across multiple builds of the same job for the
+same inputs.
 
 ## Expected Output From `Template`s
 


### PR DESCRIPTION
I seem to always want to link to a specific parameter.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller 