### PR TITLE
Trim labels so they are validated

### DIFF
--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -58,7 +58,7 @@ func (s *rpmServerStep) Run(ctx context.Context, dry bool) error {
 		imageReference = ist.Image.DockerImageReference
 	}
 
-	labelSet := map[string]string{
+	labelSet := trimLabels(map[string]string{
 		PersistsLabel:    "true",
 		JobLabel:         s.jobSpec.Job,
 		BuildIdLabel:     s.jobSpec.BuildId,
@@ -66,7 +66,7 @@ func (s *rpmServerStep) Run(ctx context.Context, dry bool) error {
 		CreatedByCILabel: "true",
 		AppLabel:         RPMRepoName,
 		TTLIgnoreLabel:   "true",
-	}
+	})
 	selectorSet := map[string]string{
 		AppLabel: RPMRepoName,
 	}

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -134,14 +134,14 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 		ObjectMeta: meta.ObjectMeta{
 			Name:      string(toTag),
 			Namespace: jobSpec.Namespace,
-			Labels: map[string]string{
+			Labels: trimLabels(map[string]string{
 				PersistsLabel:    "false",
 				JobLabel:         jobSpec.Job,
 				BuildIdLabel:     jobSpec.BuildId,
 				ProwJobIdLabel:   jobSpec.ProwJobID,
 				CreatesLabel:     string(toTag),
 				CreatedByCILabel: "true",
-			},
+			}),
 			Annotations: map[string]string{
 				JobSpecAnnotation: jobSpec.RawSpec(),
 			},
@@ -425,4 +425,15 @@ func SourceStep(config api.SourceStepConfiguration, resources api.ResourceConfig
 		clonerefsSrcClient: clonerefsSrcClient,
 		jobSpec:            jobSpec,
 	}
+}
+
+// trimLabels ensures that all label values are less than 64 characters
+// in length and thus valid.
+func trimLabels(labels map[string]string) map[string]string {
+	for k, v := range labels {
+		if len(v) > 63 {
+			labels[k] = v[:63]
+		}
+	}
+	return labels
 }

--- a/pkg/steps/test.go
+++ b/pkg/steps/test.go
@@ -40,13 +40,13 @@ func (s *testStep) Run(ctx context.Context, dry bool) error {
 	pod := &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Name: s.config.As,
-			Labels: map[string]string{
+			Labels: trimLabels(map[string]string{
 				PersistsLabel:    "false",
 				JobLabel:         s.jobSpec.Job,
 				BuildIdLabel:     s.jobSpec.BuildId,
 				ProwJobIdLabel:   s.jobSpec.ProwJobID,
 				CreatedByCILabel: "true",
-			},
+			}),
 			Annotations: map[string]string{
 				JobSpecAnnotation: s.jobSpec.RawSpec(),
 			},


### PR DESCRIPTION
This means we can lose data, but the alternative is a build failure

Fixes https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/branch-ci-openshift-cluster-api-provider-aws-images-release-3.11/2