### PR TITLE
Without cluster-version-operator, no release should be built.

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -152,11 +152,5 @@ func resolvePullSpec(is *imageapi.ImageStream, tag string) (string, bool) {
 		}
 		break
 	}
-	if len(is.Status.PublicDockerImageRepository) > 0 {
-		return fmt.Sprintf("%s:%s", is.Status.PublicDockerImageRepository, tag), true
-	}
-	if len(is.Status.DockerImageRepository) > 0 {
-		return fmt.Sprintf("%s:%s", is.Status.DockerImageRepository, tag), true
-	}
 	return "", false
 }


### PR DESCRIPTION
Fixes #140