### PR TITLE
Substitute targets that are covered by input ENV

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"flag"
@@ -289,10 +290,10 @@ func (o *options) Complete() error {
 	jobSpec.BaseNamespace = o.baseNamespace
 	o.jobSpec = jobSpec
 
-	if o.dry {
+	if o.dry && o.verbose {
 		config, _ := yaml.Marshal(o.configSpec)
 		log.Printf("Resolved configuration:\n%s", string(config))
-		job, _ := yaml.Marshal(o.jobSpec)
+		job, _ := json.Marshal(o.jobSpec)
 		log.Printf("Resolved job spec:\n%s", string(job))
 	}
 	refs := o.jobSpec.Refs

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -465,7 +465,6 @@ func loadClusterConfig() (*rest.Config, error) {
 }
 
 func (o *options) resolveInputs(ctx context.Context, steps []api.Step) error {
-	log.Printf("Resolving inputs for the test")
 	var inputs api.InputDefinition
 	for _, step := range steps {
 		definition, err := step.Inputs(ctx, o.dry)
@@ -492,7 +491,7 @@ func (o *options) resolveInputs(ctx context.Context, steps []api.Step) error {
 	// TODO: instead of mutating this here, we should pass the parts of graph execution that are resolved
 	// after the graph is created but before it is run down into the run step.
 	o.jobSpec.Namespace = o.namespace
-	log.Printf("Resolved inputs, targetting namespace %s", o.namespace)
+	log.Printf("Using namespace %s", o.namespace)
 
 	return nil
 }
@@ -731,11 +730,11 @@ func jobDescription(job *api.JobSpec, config *api.ReleaseBuildConfiguration) str
 func jobSpecFromGitRef(ref string) (*api.JobSpec, error) {
 	parts := strings.Split(ref, "@")
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("must be ORG/NAME@COMMIT")
+		return nil, fmt.Errorf("must be ORG/NAME@REF")
 	}
 	prefix := strings.Split(parts[0], "/")
 	if len(prefix) != 2 {
-		return nil, fmt.Errorf("must be ORG/NAME@COMMIT")
+		return nil, fmt.Errorf("must be ORG/NAME@REF")
 	}
 	repo := fmt.Sprintf("https://github.com/%s/%s.git", prefix[0], prefix[1])
 	out, err := exec.Command("git", "ls-remote", repo, parts[1]).Output()

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -3,7 +3,9 @@ package defaults
 import (
 	"crypto/sha256"
 	"fmt"
+	"log"
 	"net/url"
+	"os"
 	"strings"
 
 	appsclientset "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -102,6 +104,7 @@ func FromConfig(
 	var hasReleaseConfiguration bool
 	for _, rawStep := range stepConfigsForBuild(config, jobSpec) {
 		var step api.Step
+		var stepLinks []api.StepLink
 		if rawStep.InputImageTagStepConfiguration != nil {
 			srcClient, err := anonymousClusterImageStreamClient(imageClient, clusterConfig, rawStep.InputImageTagStepConfiguration.BaseImage.Cluster)
 			if err != nil {
@@ -128,7 +131,7 @@ func FromConfig(
 			step = steps.OutputImageTagStep(*rawStep.OutputImageTagStepConfiguration, imageClient, imageClient, jobSpec)
 			// all required or non-optional output images are considered part of [images]
 			if _, ok := requiredNames[string(rawStep.OutputImageTagStepConfiguration.From)]; ok || !rawStep.OutputImageTagStepConfiguration.Optional {
-				imageStepLinks = append(imageStepLinks, step.Creates()...)
+				stepLinks = append(stepLinks, step.Creates()...)
 			}
 		} else if rawStep.ReleaseImagesTagStepConfiguration != nil {
 			srcClient, err := anonymousClusterImageStreamClient(imageClient, clusterConfig, rawStep.ReleaseImagesTagStepConfiguration.Cluster)
@@ -137,15 +140,30 @@ func FromConfig(
 			}
 			hasReleaseConfiguration = true
 			step = steps.ReleaseImagesTagStep(*rawStep.ReleaseImagesTagStepConfiguration, srcClient, imageClient, routeGetter, configMapGetter, params, jobSpec)
-			imageStepLinks = append(imageStepLinks, step.Creates()...)
+			stepLinks = append(stepLinks, step.Creates()...)
 		} else if rawStep.TestStepConfiguration != nil {
 			step = steps.TestStep(*rawStep.TestStepConfiguration, config.Resources, podClient, artifactDir, jobSpec)
 		}
+
 		provides, link := step.Provides()
-		for name, fn := range provides {
-			params.Add(name, link, fn)
+
+		// if all output parameters of this step are part of the environment, replace
+		// the step with a shim that automatically provides those variables
+		if values, ok := envHasAllParameters(provides); ok {
+			log.Printf("Task %s is satisfied by environment variables and will be skipped", step.Name())
+			step = steps.NewInputEnvironmentStep(step.Name(), values, step.Creates())
+			for k, v := range values {
+				params.Set(k, v)
+			}
+		} else {
+			for name, fn := range provides {
+				params.Add(name, link, fn)
+			}
+			imageStepLinks = append(imageStepLinks, stepLinks...)
 		}
+
 		buildSteps = append(buildSteps, step)
+
 	}
 
 	for _, template := range templates {
@@ -418,4 +436,22 @@ func createStepConfigForGitSource(target api.ProjectDirectoryImageBuildInputs, j
 			ContextDir:     target.ContextDir,
 		},
 	}
+}
+
+func envHasAllParameters(params map[string]func() (string, error)) (map[string]string, bool) {
+	if len(params) == 0 {
+		return nil, false
+	}
+	var values map[string]string
+	for k := range params {
+		v, ok := os.LookupEnv(k)
+		if !ok {
+			return nil, false
+		}
+		if values == nil {
+			values = make(map[string]string)
+		}
+		values[k] = v
+	}
+	return values, true
 }

--- a/pkg/steps/input_env.go
+++ b/pkg/steps/input_env.go
@@ -1,0 +1,65 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/openshift/ci-operator/pkg/api"
+)
+
+type inputEnvironmentStep struct {
+	name   string
+	values map[string]string
+	links  []api.StepLink
+}
+
+// NewInputEnvironmentStep acts as a shim for a given step, taking a precalculated set of
+// inputs and returning those when executed. May be used to substitute a step that does work
+// with another that simply reports output.
+func NewInputEnvironmentStep(name string, values map[string]string, links []api.StepLink) api.Step {
+	return &inputEnvironmentStep{
+		name:   name,
+		values: values,
+		links:  links,
+	}
+}
+
+var _ api.Step = &inputEnvironmentStep{}
+
+func (s *inputEnvironmentStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
+	var values []string
+	for _, v := range s.values {
+		values = append(values, v)
+	}
+	sort.Strings(values)
+	return values, nil
+}
+
+func (s *inputEnvironmentStep) Run(ctx context.Context, dry bool) error {
+	return nil
+}
+
+func (s *inputEnvironmentStep) Done() (bool, error) {
+	return true, nil
+}
+
+func (s *inputEnvironmentStep) Name() string {
+	return s.name
+}
+
+func (s *inputEnvironmentStep) Description() string {
+	return fmt.Sprintf("Used to stub out another step in the graph when the outputs are already known.")
+}
+
+func (s *inputEnvironmentStep) Requires() []api.StepLink {
+	return nil
+}
+
+func (s *inputEnvironmentStep) Creates() []api.StepLink {
+	return s.links
+}
+
+func (s *inputEnvironmentStep) Provides() (api.ParameterMap, api.StepLink) {
+	return nil, nil
+}

--- a/test/template.yaml
+++ b/test/template.yaml
@@ -1,0 +1,18 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+parameters:
+- name: IMAGE_FORMAT
+  required: true
+- name: RELEASE_IMAGE_LATEST
+  required: true
+- name: IMAGE_TEST
+  required: true
+objects:
+- kind: Pod
+  apiVersion: v1
+  metadata:
+    name: test
+  spec:
+    containers:
+    - name: blah
+      image: ${IMAGE_TEST}


### PR DESCRIPTION
In order to allow testing ci-operator against repos where we want to reuse existing build artifacts, we need to replace parts of the graph with no-op equivalents. When a step has all of its environment output covered by a process environment variable, replace the step with a stub. This should allow graphs to be pruned to bypass input.

Will be used release testing.

Fix a few other annoyances along the way.