### PR TITLE
ci-operator should expose RPM_REPO_<org>_<repo>

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -36,10 +36,11 @@ images are built.
 | Example: | `registry.svc.ci.openshift.org/ci-op-<input-hash>/stable:${component}` |
 | - | - |
 
-#### `RPM_REPO`
+#### `RPM_REPO_<org>_<repo>`
 The RPM repository URL from which your job's RPMs can be installed.
 `Template`s depending on this parameter will be processed only after the
-`rpm` image is built.
+`rpm` image is built. The value of org and repo are uppercased and dashes
+replaced with underscores.
 
 | Example: | `http://rpm-repo-ci-op-<input-hash>.svc.ci.openshift.org` |
 | - | - |

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -103,9 +103,10 @@ of dynamic parameters that are inferred from previous steps. These parameters ar
   JOB_NAME_HASH
     A short hash of the job name for making tasks unique.
 
-  RPM_REPO
+  RPM_REPO_<org>_<repo>
     If the job creates RPMs this will be the public URL that can be used as the
-    baseurl= value of an RPM repository.
+		baseurl= value of an RPM repository. The value of org and repo are uppercased
+		and dashes are replaced with underscores.
 
 Dynamic environment variables are overriden by process environment variables.
 


### PR DESCRIPTION
This allows the correct variable to be consumed from templates and
removes ambiguity from use of RPM_REPO. After this change, templates
that need a particular set of RPMs (like ansible installs) ask only for
RPM_REPO_OPENSHIFT_ORIGIN during their template run.

Allows us to complete the move started in 
https://github.com/openshift/release/pull/1645 and remove the `if` check on the new name.

@stevekuznetsov