### PR TITLE
Add new cluster profiles - aws-gluster and gcp-logging

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -69,6 +69,10 @@ tests:
     cluster_profile: ''
   openshift_ansible_src:
     cluster_profile: ''
+  openshift_ansible_upgrade:
+    cluster_profile: ''
+    previous_version: ''
+    previous_rpm_deps: ''
   openshift_installer:
     cluster_profile: ''
 ```
@@ -315,6 +319,10 @@ and runs conformance tests.
 ## `tests.openshift_ansible_src`
 `openshift_ansible_src` is a test that provisions a cluster using
 `openshift-ansible` and executes a command in the `src` image.
+
+## `tests.openshift_ansible_upgrade`
+`openshift_ansible_upgrade` is a test that provisions a cluster using
+`openshift-ansible`, upgrades it to the next version and runs conformance tests.
 
 ## `tests.openshift_installer`
 `openshift_installer` is a test that provisions a cluster using

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -69,6 +69,8 @@ tests:
     cluster_profile: ''
   openshift_ansible_src:
     cluster_profile: ''
+  openshift_ansible_custom:
+    cluster_profile: ''
   openshift_ansible_upgrade:
     cluster_profile: ''
     previous_version: ''
@@ -319,6 +321,10 @@ and runs conformance tests.
 ## `tests.openshift_ansible_src`
 `openshift_ansible_src` is a test that provisions a cluster using
 `openshift-ansible` and executes a command in the `src` image.
+
+## `tests.openshift_ansible_custom`
+`openshift_ansible_upgrade` is a test that provisions a cluster using
+`openshift-ansible`'s custom provisioner, and runs conformance tests.
 
 ## `tests.openshift_ansible_upgrade`
 `openshift_ansible_upgrade` is a test that provisions a cluster using

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -198,6 +198,11 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		needsReleaseRpms = true
 		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
 	}
+	if testConfig := test.OpenshiftAnsibleUpgradeClusterTestConfiguration; testConfig != nil {
+		typeCount++
+		needsReleaseRpms = true
+		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
+	}
 	if testConfig := test.OpenshiftInstallerClusterTestConfiguration; testConfig != nil {
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -153,7 +153,7 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 
 func validateClusterProfile(fieldRoot string, p ClusterProfile) error {
 	switch p {
-	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileGCP, ClusterProfileGCPHA, ClusterProfileGCPCRIO:
+	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSGluster, ClusterProfileGCP, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging:
 		return nil
 	}
 	return fmt.Errorf("%q: invalid cluster profile %q", fieldRoot, p)

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -198,6 +198,11 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		needsReleaseRpms = true
 		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
 	}
+	if testConfig := test.OpenshiftAnsibleCustomClusterTestConfiguration; testConfig != nil {
+		typeCount++
+		needsReleaseRpms = true
+		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
+	}
 	if testConfig := test.OpenshiftAnsibleUpgradeClusterTestConfiguration; testConfig != nil {
 		typeCount++
 		needsReleaseRpms = true

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -287,10 +287,11 @@ type TestStepConfiguration struct {
 	ArtifactDir string `json:"artifact_dir"`
 
 	// Only one of the following can be not-null.
-	ContainerTestConfiguration                  *ContainerTestConfiguration                  `json:"container,omitempty"`
-	OpenshiftAnsibleClusterTestConfiguration    *OpenshiftAnsibleClusterTestConfiguration    `json:"openshift_ansible,omitempty"`
-	OpenshiftAnsibleSrcClusterTestConfiguration *OpenshiftAnsibleSrcClusterTestConfiguration `json:"openshift_ansible_src,omitempty"`
-	OpenshiftInstallerClusterTestConfiguration  *OpenshiftInstallerClusterTestConfiguration  `json:"openshift_installer,omitempty"`
+	ContainerTestConfiguration                      *ContainerTestConfiguration                      `json:"container,omitempty"`
+	OpenshiftAnsibleClusterTestConfiguration        *OpenshiftAnsibleClusterTestConfiguration        `json:"openshift_ansible,omitempty"`
+	OpenshiftAnsibleSrcClusterTestConfiguration     *OpenshiftAnsibleSrcClusterTestConfiguration     `json:"openshift_ansible_src,omitempty"`
+	OpenshiftAnsibleUpgradeClusterTestConfiguration *OpenshiftAnsibleUpgradeClusterTestConfiguration `json:"openshift_ansible_upgrade,omitempty"`
+	OpenshiftInstallerClusterTestConfiguration      *OpenshiftInstallerClusterTestConfiguration      `json:"openshift_installer,omitempty"`
 }
 
 // ContainerTestConfiguration describes a test that runs a
@@ -323,6 +324,14 @@ type ClusterTestConfiguration struct {
 	ClusterProfile ClusterProfile `json:"cluster_profile"`
 }
 
+// ClusterUpgradeTestConfiguration describes a test that provisions
+// a cluster, upgrades it and runs a command in it.
+type ClusterUpgradeTestConfiguration struct {
+	ClusterProfile  ClusterProfile `json:"cluster_profile"`
+	PreviousVersion string         `json:"previous_version"`
+	PreviousRPMDeps string         `json:"previous_rpm_deps"`
+}
+
 // OpenshiftAnsibleClusterTestConfiguration describes a test
 // that provisions a cluster using openshift-ansible and runs
 // conformance tests.
@@ -334,6 +343,13 @@ type OpenshiftAnsibleClusterTestConfiguration struct {
 // test that provisions a cluster using openshift-ansible and
 // executes a command in the `src` image.
 type OpenshiftAnsibleSrcClusterTestConfiguration struct {
+	ClusterTestConfiguration `json:",inline"`
+}
+
+// OpenshiftAnsibleUpgradeClusterTestConfiguration describes a
+// test that provisions a cluster using openshift-ansible,
+// upgrades it to the next version and runs conformance tests.
+type OpenshiftAnsibleUpgradeClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -307,12 +307,14 @@ type ContainerTestConfiguration struct {
 type ClusterProfile string
 
 const (
-	ClusterProfileAWS       ClusterProfile = "aws"
-	ClusterProfileAWSAtomic                = "aws-atomic"
-	ClusterProfileAWSCentos                = "aws-centos"
-	ClusterProfileGCP                      = "gcp"
-	ClusterProfileGCPHA                    = "gcp-ha"
-	ClusterProfileGCPCRIO                  = "gcp-crio"
+	ClusterProfileAWS        ClusterProfile = "aws"
+	ClusterProfileAWSAtomic                 = "aws-atomic"
+	ClusterProfileAWSCentos                 = "aws-centos"
+	ClusterProfileAWSGluster                = "aws-gluster"
+	ClusterProfileGCP                       = "gcp"
+	ClusterProfileGCPHA                     = "gcp-ha"
+	ClusterProfileGCPCRIO                   = "gcp-crio"
+	ClusterProfileGCPLogging                = "gcp-logging"
 )
 
 // ClusterTestConfiguration describes a test that provisions

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -290,6 +290,7 @@ type TestStepConfiguration struct {
 	ContainerTestConfiguration                      *ContainerTestConfiguration                      `json:"container,omitempty"`
 	OpenshiftAnsibleClusterTestConfiguration        *OpenshiftAnsibleClusterTestConfiguration        `json:"openshift_ansible,omitempty"`
 	OpenshiftAnsibleSrcClusterTestConfiguration     *OpenshiftAnsibleSrcClusterTestConfiguration     `json:"openshift_ansible_src,omitempty"`
+	OpenshiftAnsibleCustomClusterTestConfiguration  *OpenshiftAnsibleCustomClusterTestConfiguration  `json:"openshift_ansible_custom,omitempty"`
 	OpenshiftAnsibleUpgradeClusterTestConfiguration *OpenshiftAnsibleUpgradeClusterTestConfiguration `json:"openshift_ansible_upgrade,omitempty"`
 	OpenshiftInstallerClusterTestConfiguration      *OpenshiftInstallerClusterTestConfiguration      `json:"openshift_installer,omitempty"`
 }
@@ -343,6 +344,13 @@ type OpenshiftAnsibleClusterTestConfiguration struct {
 // test that provisions a cluster using openshift-ansible and
 // executes a command in the `src` image.
 type OpenshiftAnsibleSrcClusterTestConfiguration struct {
+	ClusterTestConfiguration `json:",inline"`
+}
+
+// OpenshiftAnsibleCustomClusterTestConfiguration describes a
+// test that provisions a cluster using openshift-ansible's
+// custom provisioner, and runs conformance tests.
+type OpenshiftAnsibleCustomClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -325,14 +325,6 @@ type ClusterTestConfiguration struct {
 	ClusterProfile ClusterProfile `json:"cluster_profile"`
 }
 
-// ClusterUpgradeTestConfiguration describes a test that provisions
-// a cluster, upgrades it and runs a command in it.
-type ClusterUpgradeTestConfiguration struct {
-	ClusterProfile  ClusterProfile `json:"cluster_profile"`
-	PreviousVersion string         `json:"previous_version"`
-	PreviousRPMDeps string         `json:"previous_rpm_deps"`
-}
-
 // OpenshiftAnsibleClusterTestConfiguration describes a test
 // that provisions a cluster using openshift-ansible and runs
 // conformance tests.
@@ -359,6 +351,8 @@ type OpenshiftAnsibleCustomClusterTestConfiguration struct {
 // upgrades it to the next version and runs conformance tests.
 type OpenshiftAnsibleUpgradeClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
+	PreviousVersion          string `json:"previous_version"`
+	PreviousRPMDeps          string `json:"previous_rpm_deps"`
 }
 
 // OpenshiftInstallerClusterTestConfiguration describes a test


### PR DESCRIPTION
Related to https://github.com/openshift/release/pull/1878 and https://github.com/openshift/release/pull/1866

This also adds new test types - openshift-ansible upgrade and custom openshift-ansible provisioners.

Fixes #175 