### PR TITLE
Remove the deprecated `from` field from tests

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -289,9 +289,6 @@ Prow jobs to execute them.
 `as` is the test name and can be used to run the test with the `--target`
 flag on `ci-operator`. Test names should be unique in a `ci-operator` configuration.
 
-## `tests.from`
-`from` is deprecated. Use a [`container`](#testscontainer) test instead.
-
 ## `tests.commands`
 `commands` are the commands that will run in this test. These commands are executed
 in the top-level directory for the repository.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -182,8 +182,7 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 	typeCount := 0
 	if testConfig := test.ContainerTestConfiguration; testConfig != nil {
 		typeCount++
-		// TODO remove when the migration is completed
-		if len(testConfig.From) == 0 && len(test.From) == 0 {
+		if len(testConfig.From) == 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `from` is required", fieldRoot))
 		}
 	}
@@ -203,15 +202,8 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
 	}
 	if typeCount == 0 {
-		// TODO remove when the migration is completed
-		if len(test.From) == 0 {
-			validationErrors = append(validationErrors, fmt.Errorf("%s has no type", fieldRoot))
-		}
+		validationErrors = append(validationErrors, fmt.Errorf("%s has no type", fieldRoot))
 	} else if typeCount == 1 {
-		// TODO remove when the migration is completed
-		if len(test.From) > 0 {
-			validationErrors = append(validationErrors, fmt.Errorf("%s specifies both `From` and a test type", fieldRoot))
-		}
 		if needsReleaseRpms && (release == nil || !originReleaseTagRegexp.MatchString(release.Name)) {
 			validationErrors = append(validationErrors, fmt.Errorf("%s requires an 'origin' release in `tag_specification`", fieldRoot))
 		}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -19,9 +19,9 @@ func TestValidateTests(t *testing.T) {
 			id: `ReleaseBuildConfiguration{Tests: {As: "unit"}}`,
 			tests: []TestStepConfiguration{
 				{
-					As:       "unit",
-					From:     "ignored",
-					Commands: "commands",
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
 				},
 			},
 			expectedValid: true,
@@ -30,23 +30,12 @@ func TestValidateTests(t *testing.T) {
 			id: `ReleaseBuildConfiguration{Tests: {As: "images"}}`,
 			tests: []TestStepConfiguration{
 				{
-					As:       "images",
-					From:     "ignored",
-					Commands: "commands",
+					As:                         "images",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
 				},
 			},
 			expectedValid: false,
-		},
-		{
-			id: "test with `from`",
-			tests: []TestStepConfiguration{
-				{
-					As:       "test",
-					From:     "from",
-					Commands: "commands",
-				},
-			},
-			expectedValid: true,
 		},
 		{
 			id: "No test type",
@@ -72,18 +61,6 @@ func TestValidateTests(t *testing.T) {
 			expectedValid: false,
 		},
 		{
-			id: "From + ContainerTestConfiguration",
-			tests: []TestStepConfiguration{
-				{
-					As:       "test",
-					Commands: "commands",
-					From:     "from",
-					ContainerTestConfiguration: &ContainerTestConfiguration{},
-				},
-			},
-			expectedValid: false,
-		},
-		{
 			id: "container test without `from`",
 			tests: []TestStepConfiguration{
 				{
@@ -98,8 +75,8 @@ func TestValidateTests(t *testing.T) {
 			id: "test without `commands`",
 			tests: []TestStepConfiguration{
 				{
-					As:   "test",
-					From: "from",
+					As: "test",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
 				},
 			},
 			expectedValid: false,
@@ -108,14 +85,14 @@ func TestValidateTests(t *testing.T) {
 			id: "test with duplicated `as`",
 			tests: []TestStepConfiguration{
 				{
-					As:       "test",
-					From:     "from",
-					Commands: "commands",
+					As:                         "test",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
 				},
 				{
-					As:       "test",
-					From:     "from",
-					Commands: "commands",
+					As:                         "test",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
 				},
 			},
 			expectedValid: false,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -274,10 +274,6 @@ type PipelineImageCacheStepConfiguration struct {
 type TestStepConfiguration struct {
 	// As is the name of the test.
 	As string `json:"as"`
-	// TODO remove when the migration is completed
-	// From is the image stream tag in the pipeline to run this
-	// command in.
-	From PipelineImageStreamTagReference `json:"from"`
 	// Commands are the shell commands to run in
 	// the repository root to execute tests.
 	Commands string `json:"commands"`

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -405,15 +405,9 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 
 	for i := range config.Tests {
 		test := &config.Tests[i]
-		// TODO remove when the migration is completed
-		if len(test.From) == 0 {
-			if containerTest := test.ContainerTestConfiguration; containerTest != nil {
-				test.From = containerTest.From
-			} else {
-				continue
-			}
+		if test.ContainerTestConfiguration != nil {
+			buildSteps = append(buildSteps, api.StepConfiguration{TestStepConfiguration: test})
 		}
-		buildSteps = append(buildSteps, api.StepConfiguration{TestStepConfiguration: test})
 	}
 
 	if config.ReleaseTagConfiguration != nil {

--- a/pkg/steps/test.go
+++ b/pkg/steps/test.go
@@ -165,7 +165,7 @@ func TestStep(config api.TestStepConfiguration, resources api.ResourceConfigurat
 		"test",
 		PodStepConfiguration{
 			As:          config.As,
-			From:        api.ImageStreamTagReference{Name: api.PipelineImageStream, Tag: string(config.From)},
+			From:        api.ImageStreamTagReference{Name: api.PipelineImageStream, Tag: string(config.ContainerTestConfiguration.From)},
 			Commands:    config.Commands,
 			ArtifactDir: config.ArtifactDir,
 		},


### PR DESCRIPTION
Requires openshift/release#1901.

/hold