### PR TITLE
pkg/steps/project_image: Use org.opencontainers.image labels

### DIFF
--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -50,10 +50,12 @@ func (s *projectDirectoryImageBuildStep) Run(ctx context.Context, dry bool) erro
 
 	labels := make(map[string]string)
 	if len(s.jobSpec.Refs.Pulls) == 0 {
-		labels["io.openshift.build.commit.id"] = s.jobSpec.Refs.BaseSHA
+		labels["org.opencontainers.image.source"] = fmt.Sprintf("https://github.com/%s/%s", s.jobSpec.Refs.Org, s.jobSpec.Refs.Repo)
+		labels["org.opencontainers.image.revision"] = s.jobSpec.Refs.BaseSHA
 		labels["io.openshift.build.commit.ref"] = s.jobSpec.Refs.BaseRef
 	} else {
-		labels["io.openshift.build.commit.id"] = ""
+		labels["org.opencontainers.image.source"] = ""
+		labels["org.opencontainers.image.revision"] = ""
 		labels["io.openshift.build.commit.ref"] = ""
 	}
 


### PR DESCRIPTION
These are [standardized][1], and folks consuming our images are more likely to recognize the standard names than our local labels.

I'm adding a new label for the source repository to make it easier to look up images where the mapping between the image tag and source repo is not obvious (e.g. olm -> [operator-framework/operator-lifecycle-manager][2]).

@smarterclayton mentioned something about these maybe being consumed by an OpenShift UI, in which case we may want to deprecate `io.openshift.build.commit.id` instead of removing it.

CC @RobertKrawitz, who's scraping the commit IDs out of the image metadata to help track the source of various cluster-install issues.

[1]: https://github.com/opencontainers/image-spec/blob/v1.0.1/annotations.md#pre-defined-annotation-keys
[2]: https://github.com/operator-framework/operator-lifecycle-manager