### PR TITLE
output logs containerwise.

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -105,9 +105,13 @@ overall result of the job.
 ## `Pod`'s annotations
 
 `ci-operator.openshift.io/wait-for-container-artifacts`:
-Will wait for a completion of a container, that has been specified in its value,
-before gathering the artifacts.
+Comma-separated list of container names for which ci-operator will wait until complete,
+to gather the artifacts.
 
 `ci-operator.openshift.io/always-show-output`:
 Will output the logs of all the containers in the pod, no matter what the exit code was.
 The value should be `true` to enable this feature.
+
+`ci-operator.openshift.io/containers-logged-on-failure`:
+Comma-separated list of container names for which ci-operator will collect and log their output if pod fails.
+By default, only the logs from the failed containers will be output.


### PR DESCRIPTION
Adds the `ci-operator.openshift.io/always-show-container-output` annotation to specify which container logs, will be shown **after** the pod will fail.

closes #185 