### PR TITLE
Log containers output to artifacts.

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -110,4 +110,4 @@ to gather the artifacts.
 
 `ci-operator.openshift.io/containers-logged-on-failure`:
 Comma-separated list of container names for which ci-operator will collect and log their output to artifacts if pod fails.
-The artifact name will be generated in the format of `$container_name-out.log`.
+The artifact names will be generated in the format of `$container_name.log` in the `container-logs` directory.

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -109,5 +109,5 @@ Comma-separated list of container names for which ci-operator will wait until co
 to gather the artifacts.
 
 `ci-operator.openshift.io/containers-logged-on-failure`:
-Comma-separated list of container names for which ci-operator will collect and log their output if pod fails.
-By default, only the logs from the failed containers will be output.
+Comma-separated list of container names for which ci-operator will collect and log their output to artifacts if pod fails.
+The artifact name will be generated in the format of `$container_name-out.log`.

--- a/pkg/steps/test.go
+++ b/pkg/steps/test.go
@@ -117,7 +117,7 @@ func (s *podStep) Run(ctx context.Context, dry bool) error {
 		return fmt.Errorf("failed to create or restart %s pod: %v", s.name, err)
 	}
 
-	if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, notifier); err != nil {
+	if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, notifier, s.artifactDir); err != nil {
 		return fmt.Errorf("failed to wait for %s pod to complete: %v", s.name, err)
 	}
 


### PR DESCRIPTION
Changes the logic of `ci-operator.openshift.io/containers-logged-on-failure` annotation to log the output of the container to artifacts instead of the `ci-operator`'s stdout.

Also fixes #194 