### PR TITLE
add openshift_installer_src test configuration

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -77,6 +77,8 @@ tests:
     previous_rpm_deps: ''
   openshift_installer:
     cluster_profile: ''
+  openshift_installer_src:
+    cluster_profile: ''
 ```
 
 # `tag_specification`
@@ -330,6 +332,10 @@ and runs conformance tests.
 ## `tests.openshift_installer`
 `openshift_installer` is a test that provisions a cluster using
 `openshift-installer` and runs conformance tests.
+
+## `tests.openshift_installer_src`
+`openshift_installer_src` is a test that provisions a cluster using
+`openshift-installer` and executes a test in the `src` image.
 
 ## `tests.*.cluster_profile`
 `cluster_profile` chooses the profile used as input to the installer. This

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -212,6 +212,10 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
 	}
+	if testConfig := test.OpenshiftInstallerSrcClusterTestConfiguration; testConfig != nil {
+		typeCount++
+		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
+	}
 	if typeCount == 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("%s has no type", fieldRoot))
 	} else if typeCount == 1 {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -289,6 +289,7 @@ type TestStepConfiguration struct {
 	OpenshiftAnsibleCustomClusterTestConfiguration  *OpenshiftAnsibleCustomClusterTestConfiguration  `json:"openshift_ansible_custom,omitempty"`
 	OpenshiftAnsibleUpgradeClusterTestConfiguration *OpenshiftAnsibleUpgradeClusterTestConfiguration `json:"openshift_ansible_upgrade,omitempty"`
 	OpenshiftInstallerClusterTestConfiguration      *OpenshiftInstallerClusterTestConfiguration      `json:"openshift_installer,omitempty"`
+	OpenshiftInstallerSrcClusterTestConfiguration   *OpenshiftInstallerSrcClusterTestConfiguration   `json:"openshift_installer_src,omitempty"`
 }
 
 // ContainerTestConfiguration describes a test that runs a
@@ -356,6 +357,13 @@ type OpenshiftAnsibleUpgradeClusterTestConfiguration struct {
 // that provisions a cluster using openshift-installer and runs
 // conformance tests.
 type OpenshiftInstallerClusterTestConfiguration struct {
+	ClusterTestConfiguration `json:",inline"`
+}
+
+// OpenshiftInstallerSrcClusterTestConfiguration describes a
+// test that provisions a cluster using openshift-installer and
+// executes a command in the `src` image.
+type OpenshiftInstallerSrcClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 }
 


### PR DESCRIPTION
This will install a cluster with openshift installer, but run a command in the `src` image. See https://github.com/openshift/release/blob/master/ci-operator/templates/openshift/installer/cluster-launch-installer-src.yaml