### PR TITLE
validation: 'cluster' is not a required field

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -138,9 +138,6 @@ func validatePromotionConfiguration(fieldRoot string, input PromotionConfigurati
 
 func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfiguration) error {
 	var validationErrors []error
-	if len(input.Cluster) == 0 {
-		validationErrors = append(validationErrors, fmt.Errorf("%s: no cluster defined", fieldRoot))
-	}
 
 	if len(input.Namespace) == 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("%s: no namespace defined", fieldRoot))


### PR DESCRIPTION
It was never intended to be required. If unset the current cluster
is used.