### PR TITLE
add gcp cluster profiles for logging

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -151,7 +151,7 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 
 func validateClusterProfile(fieldRoot string, p ClusterProfile) error {
 	switch p {
-	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileOpenStack:
+	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileOpenStack:
 		return nil
 	}
 	return fmt.Errorf("%q: invalid cluster profile %q", fieldRoot, p)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -307,17 +307,20 @@ type ContainerTestConfiguration struct {
 type ClusterProfile string
 
 const (
-	ClusterProfileAWS         ClusterProfile = "aws"
-	ClusterProfileAWSAtomic                  = "aws-atomic"
-	ClusterProfileAWSCentos                  = "aws-centos"
-	ClusterProfileAWSCentos40                = "aws-centos-40"
-	ClusterProfileAWSGluster                 = "aws-gluster"
-	ClusterProfileGCP                        = "gcp"
-	ClusterProfileGCP40                      = "gcp-40"
-	ClusterProfileGCPHA                      = "gcp-ha"
-	ClusterProfileGCPCRIO                    = "gcp-crio"
-	ClusterProfileGCPLogging                 = "gcp-logging"
-	ClusterProfileOpenStack   ClusterProfile = "openstack"
+	ClusterProfileAWS                ClusterProfile = "aws"
+	ClusterProfileAWSAtomic                         = "aws-atomic"
+	ClusterProfileAWSCentos                         = "aws-centos"
+	ClusterProfileAWSCentos40                       = "aws-centos-40"
+	ClusterProfileAWSGluster                        = "aws-gluster"
+	ClusterProfileGCP                               = "gcp"
+	ClusterProfileGCP40                             = "gcp-40"
+	ClusterProfileGCPHA                             = "gcp-ha"
+	ClusterProfileGCPCRIO                           = "gcp-crio"
+	ClusterProfileGCPLogging                        = "gcp-logging"
+	ClusterProfileGCPLoggingJournald                = "gcp-logging-journald"
+	ClusterProfileGCPLoggingJSONFile                = "gcp-logging-json-file"
+	ClusterProfileGCPLoggingCRIO                    = "gcp-logging-crio"
+	ClusterProfileOpenStack          ClusterProfile = "openstack"
 )
 
 // ClusterTestConfiguration describes a test that provisions


### PR DESCRIPTION
There are 3 new gcp cluster profiles for logging, one each
for docker log-driver journald, docker log-driver json-file,
and crio