### PR TITLE
Unit tests for some more straightforward steps

### DIFF
--- a/pkg/steps/input_env_test.go
+++ b/pkg/steps/input_env_test.go
@@ -1,0 +1,111 @@
+package steps
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/ci-operator/pkg/api"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+type doneExpectations struct {
+	value bool
+	err   error
+}
+
+type providesExpectations struct {
+	params api.ParameterMap
+	link   api.StepLink
+}
+
+type inputsExpectations struct {
+	values api.InputDefinition
+	err    error
+}
+
+type stepExpectations struct {
+	name     string
+	requires []api.StepLink
+	creates  []api.StepLink
+	provides providesExpectations
+	inputs   inputsExpectations
+	runError error
+	done     doneExpectations
+}
+
+func examineStep(t *testing.T, step api.Step, expected stepExpectations) {
+	// Test the "informative" methods
+	if name := step.Name(); name != expected.name {
+		t.Errorf("step.Name() mismatch: expected '%s', got '%s'", expected.name, name)
+	}
+	if desc := step.Description(); len(desc) == 0 {
+		t.Errorf("step.Description() returned an empty string")
+	}
+	if reqs := step.Requires(); !reflect.DeepEqual(expected.requires, reqs) {
+		t.Errorf("step.Requires() returned different links:\n%s", diff.ObjectReflectDiff(expected.requires, reqs))
+	}
+	if creates := step.Creates(); !reflect.DeepEqual(expected.creates, creates) {
+		t.Errorf("step.Creates() returned different links:\n%s", diff.ObjectReflectDiff(expected.creates, creates))
+	}
+
+	params, link := step.Provides()
+	if !reflect.DeepEqual(expected.provides.params, params) {
+		t.Errorf("step.Provides returned different params\n%s", diff.ObjectReflectDiff(expected.provides.params, link))
+	}
+	if !reflect.DeepEqual(expected.provides.link, link) {
+		t.Errorf("step.Provides returned different link\n%s", diff.ObjectReflectDiff(expected.provides.link, link))
+	}
+
+	inputs, err := step.Inputs(context.Background(), false)
+	if !reflect.DeepEqual(expected.inputs.values, inputs) {
+		t.Errorf("step.Inputs returned different inputs\n%s", diff.ObjectReflectDiff(expected.inputs.values, inputs))
+	}
+	if !reflect.DeepEqual(expected.inputs.err, err) {
+		t.Errorf("step.Inputs returned different err\n%s", diff.ObjectReflectDiff(expected.inputs.err, err))
+	}
+
+	if err := step.Run(context.Background(), false); err != expected.runError {
+		t.Errorf("step.Run returned different error: expected %v, got %v", expected.runError, err)
+	}
+
+	done, err := step.Done()
+	if !reflect.DeepEqual(expected.done.value, done) {
+		t.Errorf("step.Done returned %t, expected %t)", done, expected.done.value)
+	}
+	if !reflect.DeepEqual(expected.inputs.err, err) {
+		t.Errorf("step.Done returned different err\n%s", diff.ObjectReflectDiff(expected.done.err, err))
+	}
+}
+
+func TestInputEnvironmentStep(t *testing.T) {
+	name := "le step"
+	values := map[string]string{"key": "value", "another key": "another value"}
+	links := []api.StepLink{
+		api.ExternalImageLink(api.ImageStreamTagReference{
+			"cluster.com", "namespace", "name", "tag", "AS",
+		}),
+	}
+	ies := NewInputEnvironmentStep(name, values, links)
+
+	specification := stepExpectations{
+		name:     name,
+		requires: nil,
+		creates:  links,
+		provides: providesExpectations{
+			params: nil,
+			link:   nil,
+		},
+		inputs: inputsExpectations{
+			values: api.InputDefinition{"another value", "value"},
+			err:    nil,
+		},
+		runError: nil,
+		done: doneExpectations{
+			value: true,
+			err:   nil,
+		},
+	}
+
+	examineStep(t, ies, specification)
+}

--- a/pkg/steps/input_env_test.go
+++ b/pkg/steps/input_env_test.go
@@ -1,111 +1,43 @@
 package steps
 
 import (
-	"context"
-	"reflect"
 	"testing"
 
 	"github.com/openshift/ci-operator/pkg/api"
-	"k8s.io/apimachinery/pkg/util/diff"
 )
-
-type doneExpectations struct {
-	value bool
-	err   error
-}
-
-type providesExpectations struct {
-	params api.ParameterMap
-	link   api.StepLink
-}
-
-type inputsExpectations struct {
-	values api.InputDefinition
-	err    error
-}
-
-type stepExpectations struct {
-	name     string
-	requires []api.StepLink
-	creates  []api.StepLink
-	provides providesExpectations
-	inputs   inputsExpectations
-	runError error
-	done     doneExpectations
-}
-
-func examineStep(t *testing.T, step api.Step, expected stepExpectations) {
-	// Test the "informative" methods
-	if name := step.Name(); name != expected.name {
-		t.Errorf("step.Name() mismatch: expected '%s', got '%s'", expected.name, name)
-	}
-	if desc := step.Description(); len(desc) == 0 {
-		t.Errorf("step.Description() returned an empty string")
-	}
-	if reqs := step.Requires(); !reflect.DeepEqual(expected.requires, reqs) {
-		t.Errorf("step.Requires() returned different links:\n%s", diff.ObjectReflectDiff(expected.requires, reqs))
-	}
-	if creates := step.Creates(); !reflect.DeepEqual(expected.creates, creates) {
-		t.Errorf("step.Creates() returned different links:\n%s", diff.ObjectReflectDiff(expected.creates, creates))
-	}
-
-	params, link := step.Provides()
-	if !reflect.DeepEqual(expected.provides.params, params) {
-		t.Errorf("step.Provides returned different params\n%s", diff.ObjectReflectDiff(expected.provides.params, link))
-	}
-	if !reflect.DeepEqual(expected.provides.link, link) {
-		t.Errorf("step.Provides returned different link\n%s", diff.ObjectReflectDiff(expected.provides.link, link))
-	}
-
-	inputs, err := step.Inputs(context.Background(), false)
-	if !reflect.DeepEqual(expected.inputs.values, inputs) {
-		t.Errorf("step.Inputs returned different inputs\n%s", diff.ObjectReflectDiff(expected.inputs.values, inputs))
-	}
-	if !reflect.DeepEqual(expected.inputs.err, err) {
-		t.Errorf("step.Inputs returned different err\n%s", diff.ObjectReflectDiff(expected.inputs.err, err))
-	}
-
-	if err := step.Run(context.Background(), false); err != expected.runError {
-		t.Errorf("step.Run returned different error: expected %v, got %v", expected.runError, err)
-	}
-
-	done, err := step.Done()
-	if !reflect.DeepEqual(expected.done.value, done) {
-		t.Errorf("step.Done returned %t, expected %t)", done, expected.done.value)
-	}
-	if !reflect.DeepEqual(expected.inputs.err, err) {
-		t.Errorf("step.Done returned different err\n%s", diff.ObjectReflectDiff(expected.done.err, err))
-	}
-}
 
 func TestInputEnvironmentStep(t *testing.T) {
 	name := "le step"
 	values := map[string]string{"key": "value", "another key": "another value"}
-	links := []api.StepLink{
-		api.ExternalImageLink(api.ImageStreamTagReference{
-			"cluster.com", "namespace", "name", "tag", "AS",
-		}),
-	}
+	links := []api.StepLink{someStepLink("name")}
 	ies := NewInputEnvironmentStep(name, values, links)
 
-	specification := stepExpectations{
+	specification := stepExpectation{
 		name:     name,
 		requires: nil,
 		creates:  links,
-		provides: providesExpectations{
+		provides: providesExpectation{
 			params: nil,
 			link:   nil,
 		},
-		inputs: inputsExpectations{
+		inputs: inputsExpectation{
 			values: api.InputDefinition{"another value", "value"},
 			err:    nil,
 		},
+	}
+
+	execSpecification := executionExpectation{
+		prerun: doneExpectation{
+			value: true,
+			err:   nil,
+		},
 		runError: nil,
-		done: doneExpectations{
+		postrun: doneExpectation{
 			value: true,
 			err:   nil,
 		},
 	}
 
 	examineStep(t, ies, specification)
+	executeStep(t, ies, execSpecification)
 }

--- a/pkg/steps/template_test.go
+++ b/pkg/steps/template_test.go
@@ -1,0 +1,221 @@
+package steps
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	"github.com/openshift/ci-operator/pkg/api"
+)
+
+func TestDeferredParametersAllLinks(t *testing.T) {
+	var testCases = []struct {
+		purpose       string
+		dp            *DeferredParameters
+		expectedItems int
+	}{{
+		purpose: "AllLinks should return a slice with all links for all names",
+		dp: &DeferredParameters{
+			links: map[string][]api.StepLink{
+				"K1": {someStepLink("ONE"), someStepLink("TWO")},
+				"K2": {someStepLink("THREE")},
+			},
+		},
+		// only compare count of returned items because AllLinks can return links
+		// in any order and StepLink instances cannot be sorted unless the interface
+		// is extended to provide something by which to sort
+		expectedItems: 3,
+	}}
+
+	for _, tc := range testCases {
+		links := tc.dp.AllLinks()
+
+		if len(links) != tc.expectedItems {
+			t.Errorf("%s: %v.AllLinks() returned %v, expected %d items", tc.purpose, tc.dp, links, tc.expectedItems)
+		}
+	}
+}
+
+func TestDeferredParametersMap(t *testing.T) {
+	var testCases = []struct {
+		purpose  string
+		dp       *DeferredParameters
+		expected map[string]string
+	}{{
+		purpose: "values[N]=V, fns[N] is not set, so returned map does not have key 'N'",
+		dp: &DeferredParameters{
+			values: map[string]string{"K1": "V1"},
+			fns:    map[string]func() (string, error){},
+		},
+		expected: map[string]string{},
+	}, {
+		purpose: "fns[N] is set, values[N] is not, so returned map has key 'N' set to fns[N]()",
+		dp: &DeferredParameters{
+			values: map[string]string{},
+			fns:    map[string]func() (string, error){"K1": func() (string, error) { return "V1", nil }},
+		},
+		expected: map[string]string{"K1": "V1"},
+	}, {
+		purpose: "fns[N] is set, values[N] is set, so returned map has key 'N' set to values[N]",
+		dp: &DeferredParameters{
+			values: map[string]string{"K1": "V1"},
+			fns:    map[string]func() (string, error){"K1": func() (string, error) { return "F1", nil }},
+		},
+		expected: map[string]string{"K1": "V1"},
+	}, {
+		purpose: "returned map contains all names",
+		dp: &DeferredParameters{
+			values: map[string]string{"K1": "V1", "K2": "V2"},
+			fns: map[string]func() (string, error){
+				"K1": func() (string, error) { return "should not be returned", nil },
+				"K2": func() (string, error) { return "should not be returned", nil },
+				"K3": func() (string, error) { return "F3", nil },
+				"K4": func() (string, error) { return "F4", nil },
+			},
+		},
+		expected: map[string]string{"K1": "V1", "K2": "V2", "K3": "F3", "K4": "F4"},
+	}}
+
+	for _, tc := range testCases {
+		createdMap, _ := tc.dp.Map()
+
+		if !reflect.DeepEqual(tc.expected, createdMap) {
+			t.Errorf("%s\n %v.Map() returned different map:\n%s", tc.purpose, tc.dp, diff.ObjectReflectDiff(tc.expected, createdMap))
+		}
+	}
+}
+
+func TestDeferredParametersAddHasLinksGet(t *testing.T) {
+	var testCases = []struct {
+		purpose string
+
+		dp      *DeferredParameters
+		callAdd bool
+		name    string
+		link    api.StepLink
+		fn      func() (string, error)
+
+		expectedHas   bool
+		expectedLinks []api.StepLink
+		expectedGet   string
+	}{{
+		purpose: "After `Add(key, link, f)`: Has(key)->true, Links(key)->{link}, Get(key)->f()",
+		dp:      NewDeferredParameters(),
+		callAdd: true,
+		name:    "key",
+		link:    someStepLink("name"),
+		fn:      func() (string, error) { return "value", nil },
+
+		expectedHas:   true,
+		expectedLinks: []api.StepLink{someStepLink("name")},
+		expectedGet:   "value",
+	}, {
+		purpose: "Without Add(): Has(key)->false and Links(key)->nil",
+		dp:      NewDeferredParameters(),
+		callAdd: false,
+		name:    "key",
+		link:    nil,
+		fn:      nil,
+
+		expectedHas:   false,
+		expectedLinks: nil,
+		expectedGet:   "",
+	}, {
+		purpose: "After `Add(key, new-link)` when `key` already present: Has(key)->true and Links(key)->{new-link}",
+		dp: &DeferredParameters{
+			fns:    api.ParameterMap{"key": func() (string, error) { return "old", nil }},
+			values: map[string]string{},
+			links:  map[string][]api.StepLink{"key": {someStepLink("old-link")}},
+		},
+		callAdd: true,
+		name:    "key",
+		link:    someStepLink("new-link"),
+		fn:      func() (string, error) { return "new", nil },
+
+		expectedHas:   true,
+		expectedLinks: []api.StepLink{someStepLink("new-link")},
+		expectedGet:   "new",
+	}}
+	for _, tc := range testCases {
+		if tc.callAdd {
+			tc.dp.Add(tc.name, tc.link, tc.fn)
+		}
+
+		if has := tc.dp.Has(tc.name); has != tc.expectedHas {
+			t.Errorf("%s\n Has(%s) returned %t, expected %t", tc.purpose, tc.name, has, tc.expectedHas)
+		}
+		if links := tc.dp.Links(tc.name); !reflect.DeepEqual(tc.expectedLinks, links) {
+			t.Errorf("%s\n Links(%s) returned different links:\n%s", tc.purpose, tc.name, diff.ObjectReflectDiff(tc.expectedLinks, links))
+		}
+		if get, _ := tc.dp.Get(tc.name); get != tc.expectedGet {
+			t.Errorf("%s\n Get(%s) returned %s, expected %s", tc.purpose, tc.name, get, tc.expectedGet)
+		}
+	}
+}
+
+func TestDeferredParametersGetSet(t *testing.T) {
+	var testCases = []struct {
+		purpose  string
+		dp       *DeferredParameters
+		name     string
+		callSet  bool
+		setValue string
+		getValue string
+		getError error
+	}{{
+		purpose:  "New key",
+		dp:       NewDeferredParameters(),
+		name:     "key",
+		callSet:  true,
+		setValue: "newValue",
+
+		getValue: "newValue",
+		getError: nil,
+	}, {
+		purpose: "Existing key is not overwritten",
+		dp: &DeferredParameters{
+			fns:    make(api.ParameterMap),
+			values: map[string]string{"key": "oldValue"},
+			links:  map[string][]api.StepLink{},
+		},
+		name:     "key",
+		callSet:  true,
+		setValue: "newValue",
+
+		getValue: "oldValue",
+		getError: nil,
+	}, {
+		purpose: "Existing key is not set if lazy evaluation func is set",
+		dp: &DeferredParameters{
+			fns: map[string]func() (string, error){
+				"key": func() (string, error) { return "lazyValue", nil },
+			},
+			values: map[string]string{},
+			links:  map[string][]api.StepLink{},
+		},
+		name:     "key",
+		callSet:  true,
+		setValue: "newValue",
+
+		getValue: "lazyValue",
+		getError: nil,
+	}, {
+		purpose:  "Key that was not added",
+		dp:       NewDeferredParameters(),
+		name:     "key",
+		callSet:  false,
+		setValue: "THIS SHOULD NOT BE USED",
+
+		getValue: "",
+		getError: nil,
+	}}
+	for _, tc := range testCases {
+		if tc.callSet {
+			tc.dp.Set(tc.name, tc.setValue)
+		}
+		if value, err := tc.dp.Get(tc.name); value != tc.getValue || err != tc.getError {
+			t.Errorf("%s: Get(%s) returned (%s, %v), expected (%s, %v)", tc.purpose, tc.name, value, err, tc.getValue, tc.getError)
+		}
+	}
+}

--- a/pkg/steps/testing.go
+++ b/pkg/steps/testing.go
@@ -1,0 +1,106 @@
+package steps
+
+// This file contains helpers useful for testing ci-operator steps
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/ci-operator/pkg/api"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+type doneExpectation struct {
+	value bool
+	err   error
+}
+
+type providesExpectation struct {
+	params api.ParameterMap
+	link   api.StepLink
+}
+
+type inputsExpectation struct {
+	values api.InputDefinition
+	err    error
+}
+
+type stepExpectation struct {
+	name     string
+	requires []api.StepLink
+	creates  []api.StepLink
+	provides providesExpectation
+	inputs   inputsExpectation
+}
+
+type executionExpectation struct {
+	prerun   doneExpectation
+	runError error
+	postrun  doneExpectation
+}
+
+func someStepLink(as string) api.StepLink {
+	return api.ExternalImageLink(api.ImageStreamTagReference{
+		Cluster:   "cluster.com",
+		Namespace: "namespace",
+		Name:      "name",
+		Tag:       "tag",
+		As:        as,
+	})
+}
+
+func examineStep(t *testing.T, step api.Step, expected stepExpectation) {
+	// Test the "informative" methods
+	if name := step.Name(); name != expected.name {
+		t.Errorf("step.Name() mismatch: expected '%s', got '%s'", expected.name, name)
+	}
+	if desc := step.Description(); len(desc) == 0 {
+		t.Errorf("step.Description() returned an empty string")
+	}
+	if reqs := step.Requires(); !reflect.DeepEqual(expected.requires, reqs) {
+		t.Errorf("step.Requires() returned different links:\n%s", diff.ObjectReflectDiff(expected.requires, reqs))
+	}
+	if creates := step.Creates(); !reflect.DeepEqual(expected.creates, creates) {
+		t.Errorf("step.Creates() returned different links:\n%s", diff.ObjectReflectDiff(expected.creates, creates))
+	}
+
+	params, link := step.Provides()
+	if !reflect.DeepEqual(expected.provides.params, params) {
+		t.Errorf("step.Provides returned different params\n%s", diff.ObjectReflectDiff(expected.provides.params, link))
+	}
+	if !reflect.DeepEqual(expected.provides.link, link) {
+		t.Errorf("step.Provides returned different link\n%s", diff.ObjectReflectDiff(expected.provides.link, link))
+	}
+
+	inputs, err := step.Inputs(context.Background(), false)
+	if !reflect.DeepEqual(expected.inputs.values, inputs) {
+		t.Errorf("step.Inputs returned different inputs\n%s", diff.ObjectReflectDiff(expected.inputs.values, inputs))
+	}
+	if !reflect.DeepEqual(expected.inputs.err, err) {
+		t.Errorf("step.Inputs returned different error: expected %v, got %v", expected.inputs.err, err)
+	}
+}
+
+func executeStep(t *testing.T, step api.Step, expected executionExpectation) {
+	done, err := step.Done()
+	if !reflect.DeepEqual(expected.prerun.value, done) {
+		t.Errorf("step.Done() before Run() returned %t, expected %t)", done, expected.prerun.value)
+	}
+
+	if !reflect.DeepEqual(expected.prerun.err, err) {
+		t.Errorf("step.Done() before Run() returned different error: expected %v, got %v", expected.prerun.err, err)
+	}
+
+	if err := step.Run(context.Background(), false); err != expected.runError {
+		t.Errorf("step.Run returned different error: expected %v, got %v", expected.runError, err)
+	}
+
+	done, err = step.Done()
+	if !reflect.DeepEqual(expected.postrun.value, done) {
+		t.Errorf("step.Done() after Run() returned %t, expected %t)", done, expected.postrun.value)
+	}
+	if !reflect.DeepEqual(expected.postrun.err, err) {
+		t.Errorf("step.Done() after Run() returned different error: expecter %v, got %v", expected.postrun.err, err)
+	}
+}

--- a/pkg/steps/write_params_test.go
+++ b/pkg/steps/write_params_test.go
@@ -1,0 +1,62 @@
+package steps
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/openshift/ci-operator/pkg/api"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestWriteParamsStep(t *testing.T) {
+	params := NewDeferredParameters()
+	params.Add("K1", someStepLink("another-step"), func() (string, error) { return "V1", nil })
+	params.Add("K2", someStepLink("another-step"), func() (string, error) { return "V:2", nil })
+	paramFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Errorf("Failed to create temporary file: %v", err)
+	}
+	defer os.Remove(paramFile.Name())
+
+	wps := WriteParametersStep(params, paramFile.Name())
+
+	specification := stepExpectation{
+		name:     "parameters/write",
+		requires: []api.StepLink{someStepLink("another-step"), someStepLink("another-step")},
+		creates:  nil,
+		provides: providesExpectation{
+			params: nil,
+			link:   nil,
+		},
+		inputs: inputsExpectation{
+			values: nil,
+			err:    nil,
+		},
+	}
+
+	execSpecification := executionExpectation{
+		prerun: doneExpectation{
+			value: false,
+			err:   nil,
+		},
+		runError: nil,
+		postrun: doneExpectation{
+			value: false,
+			err:   nil,
+		},
+	}
+
+	examineStep(t, wps, specification)
+	executeStep(t, wps, execSpecification)
+
+	expectedWrittenParams := "K1=V1\nK2='V:2'\n"
+	written, err := ioutil.ReadFile(paramFile.Name())
+	if err != nil {
+		t.Errorf("Failed to read temporary file '%s' after it was supposed to be written into: %v", paramFile.Name(), err)
+	}
+	writtenParams := string(written)
+	if writtenParams != expectedWrittenParams {
+		t.Errorf("Params were not written out as expected:\n%s", diff.StringDiff(expectedWrittenParams, writtenParams))
+	}
+}


### PR DESCRIPTION
Before trying to unit test some of the larger, complicated steps that would actually need to mock some cluster state, I'm trying to cover some of the simpler ones. I have tried to extract some testing routines to a separate `testing.go` file and I'm trying to use that for testing all the steps. I needed to grok what `DeferredParams` in `template.go` does, so I wrote unit tests for it, discovering some suspicious parts in the process:

- Map() method does not perform the `os.LookupEnv(name)` like the other read-ish methods do, so `Map()` can return something not consistent with what `Get()` would return.
- `DeferredParams.links` is a slice (`[]api.StepLink)`, but it does not ever contain more than a single element. The only method that writes it is `Add()` and that only sets it to be a single-item slice. So either this is wrong or it could be just a straight `api.StepLink`, not a slice.

I'm mostly submitting this to get opinions on the `testing.go` stuff and how the actual tests look like when using that code.