### PR TITLE
Fix a possible deadlock in waitForCompletionOrTimeout

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -570,6 +570,15 @@ func waitForPodCompletion(podClient coreclientset.PodInterface, name string, not
 }
 
 func waitForPodCompletionOrTimeout(podClient coreclientset.PodInterface, name string, completed map[string]time.Time, notifier ContainerNotifier) (bool, error) {
+	watcher, err := podClient.Watch(meta.ListOptions{
+		FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(),
+		Watch:         true,
+	})
+	if err != nil {
+		return false, fmt.Errorf("could not create watcher for pod: %v", err)
+	}
+	defer watcher.Stop()
+
 	list, err := podClient.List(meta.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String()})
 	if err != nil {
 		return false, fmt.Errorf("could not list pod: %v", err)
@@ -590,15 +599,6 @@ func waitForPodCompletionOrTimeout(podClient coreclientset.PodInterface, name st
 	if podJobIsFailed(pod) {
 		return false, appendLogToError(fmt.Errorf("the pod %s/%s failed after %s (failed containers: %s): %s", pod.Namespace, pod.Name, podDuration(pod).Truncate(time.Second), strings.Join(failedContainerNames(pod), ", "), podReason(pod)), podMessages(pod))
 	}
-
-	watcher, err := podClient.Watch(meta.ListOptions{
-		FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(),
-		Watch:         true,
-	})
-	if err != nil {
-		return false, fmt.Errorf("could not create watcher for pod: %v", err)
-	}
-	defer watcher.Stop()
 
 	for {
 		event, ok := <-watcher.ResultChan()


### PR DESCRIPTION
There is a small window between first checking the Pod status on
L586/L590 and setting up the watcher on L594. If the Pod status changes
exactly in this window, we may end up waiting indefinitely on L604 for
an event that already happened.

Although this is very unlikely to happen in reality, I was seeing it
happen occasionally when unit-testing with fakes.