### PR TITLE
Unit tests ImageReady step

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -170,7 +170,7 @@ func FromConfig(
 		buildSteps = append(buildSteps, steps.StableImagesTagStep(imageClient, jobSpec))
 	}
 
-	buildSteps = append(buildSteps, steps.ImagesReadyStep(imageStepLinks, jobSpec))
+	buildSteps = append(buildSteps, steps.ImagesReadyStep(imageStepLinks))
 
 	if promote {
 		cfg, err := promotionDefaults(config)

--- a/pkg/steps/images_ready.go
+++ b/pkg/steps/images_ready.go
@@ -40,7 +40,7 @@ func (s *imagesReadyStep) Name() string { return "[images]" }
 
 func (s *imagesReadyStep) Description() string { return "All images are built and tagged into stable" }
 
-func ImagesReadyStep(links []api.StepLink, jobSpec *api.JobSpec) api.Step {
+func ImagesReadyStep(links []api.StepLink) api.Step {
 	return &imagesReadyStep{
 		links: links,
 	}

--- a/pkg/steps/images_ready_test.go
+++ b/pkg/steps/images_ready_test.go
@@ -1,0 +1,40 @@
+package steps
+
+import (
+	"testing"
+
+	"github.com/openshift/ci-operator/pkg/api"
+)
+
+func TestImagesReadyStep(t *testing.T) {
+	links := []api.StepLink{someStepLink("ONE")}
+	irs := ImagesReadyStep(links)
+	specification := stepExpectation{
+		name:     "[images]",
+		requires: links,
+		creates:  []api.StepLink{api.ImagesReadyLink()},
+		provides: providesExpectation{
+			params: nil,
+			link:   nil,
+		},
+		inputs: inputsExpectation{
+			values: nil,
+			err:    nil,
+		},
+	}
+
+	execSpecification := executionExpectation{
+		prerun: doneExpectation{
+			value: true,
+			err:   nil,
+		},
+		runError: nil,
+		postrun: doneExpectation{
+			value: true,
+			err:   nil,
+		},
+	}
+
+	examineStep(t, irs, specification)
+	executeStep(t, irs, execSpecification)
+}


### PR DESCRIPTION
I wanted to batch all tests for the remaining "simple" steps (=those which do not require interaction with a fake cluster) but discovered the only remaining simple step is `ImagesReady`.

Get rid of some unused code while at it.

/cc @stevekuznetsov @bbguimaraes @droslean 