### PR TITLE
Move the real clonerefs file, not the symlink

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -303,7 +303,7 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 			Name:      "clonerefs",
 			Tag:       "latest",
 		},
-		ClonerefsPath: "/clonerefs",
+		ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary",
 	}})
 
 	if len(config.BinaryBuildCommands) > 0 {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -11,7 +11,7 @@ import (
 
 func addCloneRefs(cfg *api.SourceStepConfiguration) *api.SourceStepConfiguration {
 	cfg.ClonerefsImage = api.ImageStreamTagReference{Cluster: "https://api.ci.openshift.org", Namespace: "ci", Name: "clonerefs", Tag: "latest"}
-	cfg.ClonerefsPath = "/clonerefs"
+	cfg.ClonerefsPath = "/app/prow/cmd/clonerefs/app.binary"
 	return cfg
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 