### PR TITLE
Unit tests: RPMImageInjectionStep 

### DIFF
--- a/pkg/steps/output_image_tag_test.go
+++ b/pkg/steps/output_image_tag_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 
 	imagev1 "github.com/openshift/api/image/v1"
-	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
 
-	corev1 "k8s.io/api/core/v1"
+	apicorev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -26,11 +25,7 @@ func TestOutputImageStep(t *testing.T) {
 		},
 	}
 
-	fakecs := ciopTestingClient{
-		kubecs:  nil,
-		imagecs: fakeimageclientset.NewSimpleClientset(),
-		t:       t,
-	}
+	fakecs := createTestingClient(t)
 
 	client := fakecs.imagecs.ImageV1()
 
@@ -88,7 +83,7 @@ func TestOutputImageStep(t *testing.T) {
 			Namespace: "configToNamespace",
 		},
 		Tag: &imagev1.TagReference{
-			From: &corev1.ObjectReference{
+			From: &apicorev1.ObjectReference{
 				Kind:      "ImageStreamImage",
 				Namespace: "job-namespace",
 				Name:      "pipeline@fromImageName",

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openshift/ci-operator/pkg/api"
 )
@@ -41,11 +40,7 @@ func preparePodStep(t *testing.T, namespace string) (*podStep, stepExpectation, 
 		Namespace: namespace,
 	}
 
-	fakecs := ciopTestingClient{
-		kubecs:  fake.NewSimpleClientset(),
-		imagecs: nil,
-		t:       t,
-	}
+	fakecs := createTestingClient(t)
 	client := NewPodClient(fakecs.Core(), nil, nil)
 
 	ps := PodStep(stepName, config, resources, client, artifactDir, jobSpec)

--- a/pkg/steps/rpm_injection_test.go
+++ b/pkg/steps/rpm_injection_test.go
@@ -1,0 +1,87 @@
+package steps
+
+import (
+	"testing"
+
+	buildv1 "github.com/openshift/api/build/v1"
+	routev1 "github.com/openshift/api/route/v1"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakerest "k8s.io/client-go/rest/fake"
+
+	"github.com/openshift/ci-operator/pkg/api"
+)
+
+func TestRPMImageInjectionStep(t *testing.T) {
+	config := api.RPMImageInjectionStepConfiguration{
+		From: "configFrom",
+		To:   "configTo",
+	}
+	resources := api.ResourceConfiguration{}
+
+	fakecs := createTestingClient(t)
+
+	istclient := fakecs.imagecs.ImageV1()
+	routeclient := fakecs.routecs.RouteV1()
+	buildsgetter := fakecs.buildcs.BuildV1()
+	restclient := &fakerest.RESTClient{}
+	buildclient := NewBuildClient(buildsgetter, restclient)
+
+	jobspec := &api.JobSpec{Namespace: "jobspecNamespace"}
+
+	rpmiis := RPMImageInjectionStep(config, resources, buildclient, routeclient, istclient, jobspec)
+
+	specification := stepExpectation{
+		name: "configTo",
+		requires: []api.StepLink{
+			api.InternalImageLink("configFrom"),
+			api.RPMRepoLink(),
+		},
+		creates:  []api.StepLink{api.InternalImageLink("configTo")},
+		provides: providesExpectation{params: nil, link: nil},
+		inputs:   inputsExpectation{values: nil, err: false},
+	}
+
+	examineStep(t, rpmiis, specification)
+
+	rpmroute := &routev1.Route{
+		ObjectMeta: meta.ObjectMeta{Name: RPMRepoName},
+	}
+	routeclient.Routes(jobspec.Namespace).Create(rpmroute)
+
+	watcher, err := buildclient.Builds("jobspecNamespace").Watch(meta.ListOptions{})
+	if err != nil {
+		t.Errorf("Failed to create a watcher over Builds in namespace 'jobspecNamespace'")
+	}
+	defer watcher.Stop()
+
+	clusterBehavior := func() {
+		// Expect a single event (a Creation) to happen
+		// Immediately set the Build status to Complete, because
+		// that is what the step waits on
+		for {
+			event, ok := <-watcher.ResultChan()
+			if !ok {
+				t.Error("Fake cluster: watcher event closed, exiting")
+				break
+			}
+			if build, ok := event.Object.(*buildv1.Build); ok {
+				t.Logf("Fake cluster: Received event on Build '%s': %s", build.ObjectMeta.Name, event.Type)
+				t.Logf("Fake cluster: Updating build '%s' status to '%s' and exiting", build.ObjectMeta.Name, buildv1.BuildPhaseComplete)
+				fakeSuccessfulBuild(build, buildsgetter, istclient, t)
+				break
+			}
+			t.Logf("Fake cluster: Received non-build event: %v", event)
+		}
+	}
+
+	execSpec := executionExpectation{
+		prerun:   doneExpectation{value: false, err: false},
+		runError: false,
+		postrun:  doneExpectation{value: true, err: false},
+	}
+
+	executeStep(t, rpmiis, execSpec, clusterBehavior)
+	// No further checks needed because we would only check for resources which
+	// the fake cluster behavior creates
+}

--- a/pkg/steps/write_params_test.go
+++ b/pkg/steps/write_params_test.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openshift/ci-operator/pkg/api"
 	"k8s.io/apimachinery/pkg/util/diff"
+
+	"github.com/openshift/ci-operator/pkg/api"
 )
 
 func TestWriteParamsStep(t *testing.T) {


### PR DESCRIPTION
This step is the first from the unit-tested to use `Route`s and `Build`s, so
fake clientsets needed to be added for these resources. Testing the step
is straightforward and uses the established setup-examine-execute
pattern. This step depends on `Build`s having correct behavior (not just
`Build` resource having correct status at the end, but also creating the
Output, in this case, an `ImageStreamTag`), so fake cluster behavior is
more complicated. This behavior is likely to be useful for testing more
steps, so it was extracted into a separate method in testing.go.

Builds on https://github.com/openshift/ci-operator/pull/226