### PR TITLE
Usability improvements to validation for iteratively building a config.yaml

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -273,7 +273,7 @@ func (o *options) Complete() error {
 	}
 
 	if err := o.configSpec.Validate(); err != nil {
-		return fmt.Errorf("invalid configuration: %v", err)
+		return err
 	}
 
 	jobSpec, err := api.ResolveSpecFromEnv()

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -265,7 +265,10 @@ func (o *options) Complete() error {
 			return fmt.Errorf("CONFIG_SPEC environment variable is not set or empty and no --config file was set")
 		}
 	}
-	if err := yaml.Unmarshal([]byte(configSpec), &o.configSpec); err != nil {
+	if o.configSpec == nil {
+		o.configSpec = &api.ReleaseBuildConfiguration{}
+	}
+	if err := yaml.Unmarshal([]byte(configSpec), o.configSpec); err != nil {
 		return fmt.Errorf("invalid configuration: %v\nvalue:\n%s", err, string(configSpec))
 	}
 

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -158,9 +158,9 @@ func TestValidateTests(t *testing.T) {
 	}
 
 	for _, tc := range testTestsCases {
-		if err := validateTestStepConfiguration("tests", tc.tests, tc.release); err != nil && tc.expectedValid {
-			validationErrors = append(validationErrors, parseError(tc.id, err))
-		} else if !tc.expectedValid && err == nil {
+		if errs := validateTestStepConfiguration("tests", tc.tests, tc.release); len(errs) > 0 && tc.expectedValid {
+			validationErrors = append(validationErrors, fmt.Errorf("%q expected to be valid, got: %v", tc.id, errs))
+		} else if !tc.expectedValid && len(errs) == 0 {
 			validationErrors = append(validationErrors, parseValidError(tc.id))
 		}
 	}
@@ -201,9 +201,9 @@ func TestValidateBuildRoot(t *testing.T) {
 	}
 
 	for _, tc := range testBuildRootCases {
-		if err := validateBuildRootImageConfiguration("build_root", &tc.buildRootImageConfig); err != nil && tc.expectedValid {
-			validationErrors = append(validationErrors, parseError(tc.id, err))
-		} else if !tc.expectedValid && err == nil {
+		if errs := validateBuildRootImageConfiguration("build_root", &tc.buildRootImageConfig); len(errs) > 0 && tc.expectedValid {
+			validationErrors = append(validationErrors, fmt.Errorf("%q expected to be valid, got: %v", tc.id, errs))
+		} else if !tc.expectedValid && len(errs) == 0 {
 			validationErrors = append(validationErrors, parseValidError(tc.id))
 		}
 	}
@@ -228,9 +228,9 @@ func TestValidateBaseImages(t *testing.T) {
 		},
 	}
 	for _, tc := range testBaseImagesCases {
-		if err := validateImageStreamTagReferenceMap("base_images", tc.baseImages); err != nil && tc.expectedValid {
-			validationErrors = append(validationErrors, parseError(tc.id, err))
-		} else if !tc.expectedValid && err == nil {
+		if errs := validateImageStreamTagReferenceMap("base_images", tc.baseImages); len(errs) > 0 && tc.expectedValid {
+			validationErrors = append(validationErrors, fmt.Errorf("%q expected to be valid, got: %v", tc.id, errs))
+		} else if !tc.expectedValid && len(errs) == 0 {
 			validationErrors = append(validationErrors, parseValidError(tc.id))
 		}
 	}
@@ -256,9 +256,9 @@ func TestValidateBaseRpmImages(t *testing.T) {
 	}
 
 	for _, tc := range testBaseRpmImagesCases {
-		if err := validateImageStreamTagReferenceMap("base_rpm_images", tc.baseRpmImages); err != nil && tc.expectedValid {
-			validationErrors = append(validationErrors, parseError(tc.id, err))
-		} else if !tc.expectedValid && err == nil {
+		if errs := validateImageStreamTagReferenceMap("base_rpm_images", tc.baseRpmImages); len(errs) > 0 && tc.expectedValid {
+			validationErrors = append(validationErrors, fmt.Errorf("%q expected to be valid, got: %v", tc.id, errs))
+		} else if !tc.expectedValid && len(errs) == 0 {
 			validationErrors = append(validationErrors, parseValidError(tc.id))
 		}
 	}

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -657,7 +657,7 @@ func podMessages(pod *coreapi.Pod) string {
 	for _, status := range append(append([]coreapi.ContainerStatus{}, pod.Status.InitContainerStatuses...), pod.Status.ContainerStatuses...) {
 		if state := status.State.Terminated; state != nil && state.ExitCode != 0 {
 			messages = append(messages, fmt.Sprintf("Container %s exited with code %d, reason %s", status.Name, state.ExitCode, state.Reason))
-			if msg := state.Message; len(msg) > 0 {
+			if msg := strings.TrimSpace(state.Message); len(msg) > 0 {
 				messages = append(messages, "---", msg, "---")
 			}
 		}

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,0 +1,15 @@
+resources:
+  '*':
+    requests:
+      cpu: 1
+build_root:
+  image_stream_tag:
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+    as: root
+tests:
+- as: blah
+  commands: make
+  container:
+    from: root

--- a/test/template.yaml
+++ b/test/template.yaml
@@ -1,18 +1,20 @@
 kind: Template
 apiVersion: template.openshift.io/v1
 parameters:
-- name: IMAGE_FORMAT
-  required: true
-- name: RELEASE_IMAGE_LATEST
-  required: true
-- name: IMAGE_TEST
-  required: true
 objects:
 - kind: Pod
   apiVersion: v1
   metadata:
     name: test
   spec:
+    restartPolicy: Never
     containers:
-    - name: blah
-      image: ${IMAGE_TEST}
+    - name: test
+      image: centos:7
+      terminationMessagePolicy: FallbackToLogsOnError
+      command:
+      - /bin/bash
+      - -c
+      - |
+        cat /etc/resolv.conf
+        exit 1


### PR DESCRIPTION
Surfaced a few improvements while debugging an issue in ci-operator around
message fallback output

* Better handling of validation and reporting to user
* Better messages for some error cases that guide user to next step
* Trim some whitespace from pod execution output
* Don't panic when the config file is empty