### PR TITLE
Don't double print "wait for completion" in pod errors

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -153,7 +153,7 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 		switch {
 		case ref.Ref.Kind == "Pod" && ref.Ref.APIVersion == "v1":
 			if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), ref.Ref.Name, notifier); err != nil {
-				return fmt.Errorf("could not wait for pod to complete: %v", err)
+				return fmt.Errorf("template pod %q failed: %v", ref.Ref.Name, err)
 			}
 		}
 	}
@@ -560,7 +560,7 @@ func waitForPodCompletion(podClient coreclientset.PodInterface, name string, not
 			continue
 		}
 		if err != nil {
-			return fmt.Errorf("could not wait for pod completion: %v", err)
+			return err
 		}
 		if !retry {
 			break

--- a/pkg/steps/test.go
+++ b/pkg/steps/test.go
@@ -118,7 +118,7 @@ func (s *podStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, notifier); err != nil {
-		return fmt.Errorf("failed to wait for %s pod to complete: %v", s.name, err)
+		return fmt.Errorf("test %q failed: %v", pod.Name, err)
 	}
 
 	return nil


### PR DESCRIPTION
```
failed to wait for test pod to complete: could not wait for pod completion: the pod ci-op-8bcvrkzj/unit failed after 1m25s (failed containers: test):  unknown
```

is now

```
test "unit" failed: the pod ci-op-8bcvrkzj/unit failed after 1m25s (failed containers: test):  unknown
```

or

```
template pod "e2e-aws" failed: the pod ci-op-8bcvrkzj/e2e-aws failed after 1m25s (failed containers: test):  unknown
```