### PR TITLE
Simplify the container exit message if not set

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -629,24 +629,11 @@ func waitForPodCompletionOrTimeout(podClient coreclientset.PodInterface, name st
 func podReason(pod *coreapi.Pod) string {
 	reason := pod.Status.Reason
 	message := pod.Status.Message
-	if len(message) == 0 {
-		message = "unknown"
-	}
 	if len(reason) == 0 {
-		for _, status := range append(append([]coreapi.ContainerStatus{}, pod.Status.InitContainerStatuses...), pod.Status.ContainerStatuses...) {
-			state := status.State.Terminated
-			if state == nil || state.ExitCode == 0 {
-				continue
-			}
-			if len(reason) == 0 {
-				continue
-			}
-			reason = state.Reason
-			if len(message) == 0 {
-				message = fmt.Sprintf("container failure with exit code %d", state.ExitCode)
-			}
-			break
-		}
+		reason = "ContainerFailed"
+	}
+	if len(message) == 0 {
+		message = "one or more containers exited"
 	}
 	return fmt.Sprintf("%s %s", reason, message)
 }


### PR DESCRIPTION
@stevekuznetsov I think this is clearer than the current behavior -
container info is already printed by podMessages() which is always
invoked, so we can just indicate it more simply.