### PR TITLE
Don't set refs in metadata.json when we don't have a repo

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -739,8 +739,10 @@ func (o *options) writeMetadataJSON() error {
 
 	m := prowResultMetadata{}
 
-	m.Repo = fmt.Sprintf("%s/%s", o.jobSpec.Refs.Org, o.jobSpec.Refs.Repo)
-	m.Repos = map[string]string{m.Repo: o.jobSpec.Refs.String()}
+	if len(o.jobSpec.Refs.Repo) > 0 {
+		m.Repo = fmt.Sprintf("%s/%s", o.jobSpec.Refs.Org, o.jobSpec.Refs.Repo)
+		m.Repos = map[string]string{m.Repo: o.jobSpec.Refs.String()}
+	}
 
 	m.Pod = o.jobSpec.ProwJobID
 	m.WorkNamespace = o.namespace


### PR DESCRIPTION
ci-operator can be used to launch jobs without builds (see https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-all-4.0/23/).
When refs.repo is empty we should skip setting the refs string.