### PR TITLE
Reverse order of PR link in namespace description

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -815,7 +815,7 @@ func jobDescription(job *api.JobSpec, config *api.ReleaseBuildConfiguration) str
 		links = append(links, fmt.Sprintf("https://github.com/%s/%s/pull/%d - %s", job.Refs.Org, job.Refs.Repo, pull.Number, pull.Author))
 	}
 	if len(links) > 0 {
-		return fmt.Sprintf("%s on https://github.com/%s/%s\n\n%s", job.Job, job.Refs.Org, job.Refs.Repo, strings.Join(links, "\n"))
+		return fmt.Sprintf("%s\n\n%s on https://github.com/%s/%s", strings.Join(links, "\n"), job.Job, job.Refs.Org, job.Refs.Repo)
 	}
 	return fmt.Sprintf("%s on https://github.com/%s/%s ref=%s commit=%s", job.Job, job.Refs.Org, job.Refs.Repo, job.Refs.BaseRef, job.Refs.BaseSHA)
 }


### PR DESCRIPTION
Currently we report:

    openshift.io/description: |-
      pull-ci-openshift-cluster-bootstrap-master-verify-deps on https://github.com/openshift/cluster-bootstrap

      https://github.com/openshift/cluster-bootstrap/pull/8 - sttts

but reporting

    openshift.io/description: |-
      https://github.com/openshift/cluster-bootstrap/pull/8 - sttts

      pull-ci-openshift-cluster-bootstrap-master-verify-deps on https://github.com/openshift/cluster-bootstrap

is more readable (user can instantly link to the PR that triggered the job), and the extra info is redundant
or debug only.