### PR TITLE
Allow pods to declare that they want one junit per container, instead of pod

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +26,17 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 
 	templateapi "github.com/openshift/api/template/v1"
+
+	"github.com/openshift/ci-operator/pkg/junit"
+)
+
+const (
+	// A comma-delimited list of containers to wait for artifacts from within a pod. If not
+	// specify, only 'artifacts' is waited for.
+	annotationWaitForContainerArtifacts = "ci-operator.openshift.io/wait-for-container-artifacts"
+	// A comma-delimited list of container names that will be returned as individual JUnit
+	// test results.
+	annotationContainersForSubTestResults = "ci-operator.openshift.io/container-sub-tests"
 )
 
 // ContainerNotifier receives updates about the status of a poll action on a pod. The caller
@@ -50,6 +63,79 @@ func (nopNotifier) Notify(_ *coreapi.Pod, _ string) {}
 func (nopNotifier) Complete(_ string)               {}
 func (nopNotifier) Done(_ string) bool              { return true }
 func (nopNotifier) Cancel()                         {}
+
+// TestCaseNotifier allows a caller to generate per container JUnit test
+// reports that provide better granularity for debugging problems when
+// running tests in multi-container pods. It intercepts notifications and
+// remembers the last pod retrieved which SubTests() will read.
+//
+// TestCaseNotifier must be called from a single thread.
+type TestCaseNotifier struct {
+	nested  ContainerNotifier
+	lastPod *coreapi.Pod
+}
+
+// NewTestCaseNotifier wraps the provided ContainerNotifier and will
+// create JUnit TestCase records for each container in the most recent
+// pod to have completed.
+func NewTestCaseNotifier(nested ContainerNotifier) *TestCaseNotifier {
+	return &TestCaseNotifier{nested: nested}
+}
+
+func (n *TestCaseNotifier) Notify(pod *coreapi.Pod, containerName string) {
+	n.nested.Notify(pod, containerName)
+	n.lastPod = pod
+}
+
+func (n *TestCaseNotifier) Complete(podName string)  { n.nested.Complete(podName) }
+func (n *TestCaseNotifier) Done(podName string) bool { return n.nested.Done(podName) }
+func (n *TestCaseNotifier) Cancel()                  { n.nested.Cancel() }
+
+// SubTests returns one junit test for each terminated container with a name
+// in the annotation 'ci-operator.openshift.io/container-sub-tests' in the pod.
+// Invoking SubTests clears the last pod, so subsequent calls will return no
+// tests unless Notify() has been called in the meantime.
+func (n *TestCaseNotifier) SubTests(prefix string) []*junit.TestCase {
+	if n.lastPod == nil {
+		return nil
+	}
+	pod := n.lastPod
+	n.lastPod = nil
+
+	names := sets.NewString(strings.Split(pod.Annotations[annotationContainersForSubTestResults], ",")...)
+	names.Delete("")
+	if len(names) == 0 {
+		return nil
+	}
+	var tests []*junit.TestCase
+	for _, status := range pod.Status.ContainerStatuses {
+		if names.Has(status.Name) {
+			if t := status.State.Terminated; t != nil {
+				test := &junit.TestCase{
+					Name:     fmt.Sprintf("%scontainer %s", prefix, status.Name),
+					Duration: t.FinishedAt.Sub(t.StartedAt.Time).Seconds(),
+				}
+				if t.ExitCode != 0 {
+					test.FailureOutput = &junit.FailureOutput{
+						Output: t.Message,
+					}
+				}
+				tests = append(tests, test)
+				continue
+			}
+		}
+	}
+	return tests
+}
+
+func stringInSlice(arr []string, s string) bool {
+	for _, item := range arr {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
 
 type podClient struct {
 	coreclientset.PodsGetter
@@ -212,6 +298,11 @@ done
 
 type podContainersMap map[string]map[string]struct{}
 
+// ArtifactWorker tracks pods that have completed and have an 'artifacts' container
+// in them and will extract files from the container to a local directory. It also
+// gathers container logs on all pods.
+//
+// This worker is thread safe and may be invoked in parallel.
 type ArtifactWorker struct {
 	dir       string
 	podClient PodClient
@@ -222,7 +313,7 @@ type ArtifactWorker struct {
 	lock         sync.Mutex
 	remaining    podContainersMap
 	required     podContainersMap
-	hasArtifacts map[string]struct{}
+	hasArtifacts sets.String
 }
 
 func NewArtifactWorker(podClient PodClient, artifactDir, namespace string) *ArtifactWorker {
@@ -234,7 +325,7 @@ func NewArtifactWorker(podClient PodClient, artifactDir, namespace string) *Arti
 
 		remaining:    make(podContainersMap),
 		required:     make(podContainersMap),
-		hasArtifacts: make(map[string]struct{}),
+		hasArtifacts: sets.NewString(),
 
 		podsToDownload: make(chan string, 4),
 	}
@@ -244,8 +335,7 @@ func NewArtifactWorker(podClient PodClient, artifactDir, namespace string) *Arti
 
 func (w *ArtifactWorker) run() {
 	for podName := range w.podsToDownload {
-		_, hasArtifacts := w.hasArtifacts[podName]
-		if err := w.downloadArtifacts(podName, hasArtifacts); err != nil {
+		if err := w.downloadArtifacts(podName, w.hasArtifacts.Has(podName)); err != nil {
 			log.Printf("error: %v", err)
 		}
 		// indicate we are done with this pod by removing the map entry
@@ -310,7 +400,7 @@ func (w *ArtifactWorker) CollectFromPod(podName string, hasArtifacts []string, w
 
 	for _, name := range hasArtifacts {
 		if name == "artifacts" {
-			w.hasArtifacts[podName] = struct{}{}
+			w.hasArtifacts.Insert(podName)
 			continue
 		}
 		if _, ok := m[name]; !ok {
@@ -415,7 +505,7 @@ func addArtifactContainersFromPod(pod *coreapi.Pod, worker *ArtifactWorker) {
 		containers = append(containers, container.Name)
 	}
 	var waitForContainers []string
-	if names := pod.Annotations["ci-operator.openshift.io/wait-for-container-artifacts"]; len(names) > 0 {
+	if names := pod.Annotations[annotationWaitForContainerArtifacts]; len(names) > 0 {
 		waitForContainers = strings.Split(names, ",")
 	}
 	worker.CollectFromPod(pod.Name, containers, waitForContainers)

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -1,0 +1,276 @@
+package steps
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/ci-operator/pkg/junit"
+	coreapi "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestTestCaseNotifier_SubTests(t *testing.T) {
+	tests := []struct {
+		name      string
+		pod       *coreapi.Pod
+		prefix    string
+		wantTests []*junit.TestCase
+	}{
+		{name: "nil"},
+		{
+			name: "no annotation",
+			pod: &coreapi.Pod{
+				Status: coreapi.PodStatus{
+					ContainerStatuses: []coreapi.ContainerStatus{
+						{
+							Name: "test",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty annotation",
+			pod: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{
+						annotationContainersForSubTestResults: "",
+					},
+				},
+				Status: coreapi.PodStatus{
+					ContainerStatuses: []coreapi.ContainerStatus{
+						{
+							Name: "test",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "annotation is invalid",
+			pod: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{
+						annotationContainersForSubTestResults: ",",
+					},
+				},
+				Status: coreapi.PodStatus{
+					ContainerStatuses: []coreapi.ContainerStatus{
+						{
+							Name: "test",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "annotation points to missing container",
+			pod: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{
+						annotationContainersForSubTestResults: "other",
+					},
+				},
+				Status: coreapi.PodStatus{
+					ContainerStatuses: []coreapi.ContainerStatus{
+						{
+							Name: "test",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single failed container",
+			pod: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{
+						annotationContainersForSubTestResults: "test",
+					},
+				},
+				Status: coreapi.PodStatus{
+					ContainerStatuses: []coreapi.ContainerStatus{
+						{
+							Name: "test",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTests: []*junit.TestCase{
+				{
+					Name: "container test",
+					FailureOutput: &junit.FailureOutput{
+						Output: "exit message",
+					},
+				},
+			},
+		},
+		{
+			name: "two failed containers, order is status",
+			pod: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{
+						annotationContainersForSubTestResults: "other,test",
+					},
+				},
+				Status: coreapi.PodStatus{
+					ContainerStatuses: []coreapi.ContainerStatus{
+						{
+							Name: "test",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+						{
+							Name: "other",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTests: []*junit.TestCase{
+				{
+					Name: "container test",
+					FailureOutput: &junit.FailureOutput{
+						Output: "exit message",
+					},
+				},
+				{
+					Name: "container other",
+					FailureOutput: &junit.FailureOutput{
+						Output: "exit message",
+					},
+				},
+			},
+		},
+		{
+			name: "one failed, one succeeded",
+			pod: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{
+						annotationContainersForSubTestResults: "other,test",
+					},
+				},
+				Status: coreapi.PodStatus{
+					ContainerStatuses: []coreapi.ContainerStatus{
+						{
+							Name: "test",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+						{
+							Name: "other",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 0,
+									Message:  "success",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTests: []*junit.TestCase{
+				{
+					Name: "container test",
+					FailureOutput: &junit.FailureOutput{
+						Output: "exit message",
+					},
+				},
+				{
+					Name: "container other",
+				},
+			},
+		},
+		{
+			name: "ignores unfinisted container",
+			pod: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{
+						annotationContainersForSubTestResults: "other,test",
+					},
+				},
+				Status: coreapi.PodStatus{
+					ContainerStatuses: []coreapi.ContainerStatus{
+						{
+							Name: "test",
+							State: coreapi.ContainerState{
+								Terminated: &coreapi.ContainerStateTerminated{
+									ExitCode: 1,
+									Message:  "exit message",
+								},
+							},
+						},
+						{
+							Name:  "other",
+							State: coreapi.ContainerState{},
+						},
+					},
+				},
+			},
+			wantTests: []*junit.TestCase{
+				{
+					Name: "container test",
+					FailureOutput: &junit.FailureOutput{
+						Output: "exit message",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &TestCaseNotifier{
+				nested:  nopNotifier{},
+				lastPod: tt.pod,
+			}
+			tests := n.SubTests(tt.prefix)
+			if !reflect.DeepEqual(tt.wantTests, tests) {
+				t.Fatalf("unexpected: %s", diff.ObjectReflectDiff(tt.wantTests, tests))
+			}
+		})
+	}
+}

--- a/test/template.yaml
+++ b/test/template.yaml
@@ -6,6 +6,8 @@ objects:
   apiVersion: v1
   metadata:
     name: test
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
   spec:
     restartPolicy: Never
     containers:


### PR DESCRIPTION
Setting the annotation `ci-operator.openshift.io/container-sub-tests` to a
list of comma delimited container names will replace the overall junit
result reported for that pod or template with one junit result per test.

This allows a pod that has both setup and test containers to get per task
junits which aids debugging.

Also simplify the names of the steps as printed in junit to make them
easier to scan.

```
<testsuites>
  <testsuite name="operator" tests="1" skipped="0" failures="1" time="5.068806427">
    <testcase name="Run template template - test container test" time="0">
      <failure message="">nameserver 10.142.0.22&#xA;search clayton-test-1.svc.cluster.local svc.cluster.local cluster.local c.openshift-ci-infra.internal google.internal&#xA;options ndots:5&#xA;</failure>
    </testcase>
  </testsuite>
</testsuites>
```

for the example in the dir (time is zero because kube accuracy is +/- 1 second)