### PR TITLE
Update the location of the clonerefs file

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -303,7 +303,7 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 			Name:      "clonerefs",
 			Tag:       "latest",
 		},
-		ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+		ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
 	}})
 
 	if len(config.BinaryBuildCommands) > 0 {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -11,7 +11,7 @@ import (
 
 func addCloneRefs(cfg *api.SourceStepConfiguration) *api.SourceStepConfiguration {
 	cfg.ClonerefsImage = api.ImageStreamTagReference{Cluster: "https://api.ci.openshift.org", Namespace: "ci", Name: "clonerefs", Tag: "latest"}
-	cfg.ClonerefsPath = "/app/prow/cmd/clonerefs/app.binary.runfiles/test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary"
+	cfg.ClonerefsPath = "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary"
 	return cfg
 }
 


### PR DESCRIPTION
Upstream changed the name of their `bazel` workspace, so the output
location of the clonerefs app binary moved.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>