### PR TITLE
Artifacts container is not always being shut down

### DIFF
--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -93,7 +93,7 @@ func (s *podStep) Run(ctx context.Context, dry bool) error {
 			MountPath: s.config.ArtifactDir,
 		})
 		addArtifactsContainer(pod, s.config.ArtifactDir)
-		artifacts.CollectFromPod(pod.Name, []string{s.name}, nil)
+		artifacts.CollectFromPod(pod.Name, true, []string{s.name}, nil)
 		notifier = artifacts
 	}
 	testCaseNotifier := NewTestCaseNotifier(notifier)


### PR DESCRIPTION
Single container pod tests weren't getting artifact containers shut down,
causing namespaces to pile up.