### PR TITLE
test step secret inject

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -65,6 +65,9 @@ tests:
   commands: ''
   container:
     from: ''
+  secret:
+    name: ''
+    mount_path: ''
   openshift_ansible:
     cluster_profile: ''
   openshift_ansible_src:
@@ -312,6 +315,18 @@ of the images in the pipeline.
 
 ## `tests.container.from`
 `from` is the pipeline image tag that this test will be run on.
+
+# `tests.secret` 
+
+`Secret` field enables users to mount a secret inside test container.
+It is users responsibility to make sure secret is available in the temporary namespace.
+This can be done by providing flag `--secret-dir` to ci-operator in prow configuration.
+
+## `tests.secret.name`
+`secret.name` is the name of the secret to be mounted inside a test container.
+
+## `tests.secret.path`
+`secret.path` is the path at which to mount the secret. Optional, defaults to `/usr/test-secret`
 
 ## `tests.openshift_ansible`
 `openshift_ansible` is a test that provisions a cluster using openshift-ansible

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -155,6 +155,78 @@ func TestValidateTests(t *testing.T) {
 			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
 			expectedValid: true,
 		},
+		{
+			id: "invalid secret mountPath",
+			tests: []TestStepConfiguration{
+				{
+					As: "test",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{},
+					Secret: Secret{
+						Name:      "secret",
+						MountPath: "/path/to/secret:exec",
+					},
+				},
+			},
+			expectedValid: false,
+		},
+		{
+			id: "invalid secret name",
+			tests: []TestStepConfiguration{
+				{
+					As: "test",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{},
+					Secret: Secret{
+						Name:      "secret_test",
+						MountPath: "/path/to/secret:exec",
+					},
+				},
+			},
+			expectedValid: false,
+		},
+		{
+			id: "valid secret",
+			tests: []TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
+					Secret: Secret{
+						Name: "secret",
+					},
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			id: "valid secret with path",
+			tests: []TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
+					Secret: Secret{
+						Name:      "secret",
+						MountPath: "/path/to/secret",
+					},
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			id: "valid secret with invalid path",
+			tests: []TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
+					Secret: Secret{
+						Name:      "secret",
+						MountPath: "path/to/secret",
+					},
+				},
+			},
+			expectedValid: false,
+		},
 	}
 
 	for _, tc := range testTestsCases {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -282,6 +282,10 @@ type TestStepConfiguration struct {
 	// the repository root to _output/local/artifacts.
 	ArtifactDir string `json:"artifact_dir"`
 
+	// Secret is an optional secret object which
+	// will be mounted inside the test container.
+	Secret Secret `json:"secret,omitempty"`
+
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration                      *ContainerTestConfiguration                      `json:"container,omitempty"`
 	OpenshiftAnsibleClusterTestConfiguration        *OpenshiftAnsibleClusterTestConfiguration        `json:"openshift_ansible,omitempty"`
@@ -291,6 +295,15 @@ type TestStepConfiguration struct {
 	OpenshiftAnsibleUpgradeClusterTestConfiguration *OpenshiftAnsibleUpgradeClusterTestConfiguration `json:"openshift_ansible_upgrade,omitempty"`
 	OpenshiftInstallerClusterTestConfiguration      *OpenshiftInstallerClusterTestConfiguration      `json:"openshift_installer,omitempty"`
 	OpenshiftInstallerSrcClusterTestConfiguration   *OpenshiftInstallerSrcClusterTestConfiguration   `json:"openshift_installer_src,omitempty"`
+}
+
+// Secret describes a secret to be mounted inside a test
+// container.
+type Secret struct {
+	// Secret name, used inside test containers
+	Name string `json:"name"`
+	// Secret mount path. Defaults to /usr/test-secret
+	MountPath string `json:"mount_path"`
 }
 
 // ContainerTestConfiguration describes a test that runs a

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -182,3 +182,131 @@ func TestPodStepExecution(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPodObjectMounts(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		podStep              func(*podStep)
+		expectedVolumeConfig *v1.Pod
+	}{
+		{
+			name: "no secret name results in no mounted secrets",
+			podStep: func(expectedPodStepTemplate *podStep) {
+				expectedPodStepTemplate.config.Secret.Name = ""
+			},
+			expectedVolumeConfig: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{},
+						},
+					},
+					Volumes: []v1.Volume{},
+				},
+			},
+		},
+		{
+			name: "with secret name results in secret mounted with default path",
+			podStep: func(expectedPodStepTemplate *podStep) {
+				expectedPodStepTemplate.config.Secret.Name = testSecretName
+			},
+			expectedVolumeConfig: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      testSecretName,
+									MountPath: testSecretDefaultPath,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: testSecretName,
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: testSecretName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with secret name and path results in mounted secret with custom path",
+			podStep: func(expectedPodStepTemplate *podStep) {
+				expectedPodStepTemplate.config.Secret.Name = testSecretName
+				expectedPodStepTemplate.config.Secret.MountPath = "/usr/local/secrets"
+			},
+			expectedVolumeConfig: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      testSecretName,
+									MountPath: "/usr/local/secrets",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: testSecretName,
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: testSecretName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			podStepTemplate := expectedPodStepTemplate()
+			tc.podStep(podStepTemplate)
+
+			pod := podStepTemplate.generatePodForStep("", v1.ResourceRequirements{})
+
+			if !equality.Semantic.DeepEqual(pod.Spec.Volumes, tc.expectedVolumeConfig.Spec.Volumes) {
+				t.Errorf("test %s failed. generated pod.Spec.Volumes was not as expected", tc.name)
+				t.Error(diff.ObjectReflectDiff(pod.Spec.Volumes, tc.expectedVolumeConfig.Spec.Volumes))
+			}
+			if !equality.Semantic.DeepEqual(pod.Spec.Containers[0].VolumeMounts, tc.expectedVolumeConfig.Spec.Containers[0].VolumeMounts) {
+				t.Errorf("test %s failed. generated pod.Spec.Container[0].VolumeMounts was not as expected", tc.name)
+				t.Error(diff.ObjectReflectDiff(pod.Spec.Containers[0].VolumeMounts, tc.expectedVolumeConfig.Spec.Containers[0].VolumeMounts))
+			}
+
+		})
+	}
+
+}
+
+func expectedPodStepTemplate() *podStep {
+	return &podStep{
+		jobSpec: &api.JobSpec{
+			Job:       "podStep.jobSpec.Job",
+			BuildId:   "podStep.jobSpec.BuildId",
+			ProwJobID: "podStep.jobSpec.ProwJobID",
+		},
+		name: "podStep.name",
+		config: PodStepConfiguration{
+			ServiceAccountName: "podStep.config.PodStepConfiguration.ServiceAccountName",
+			Commands:           "podStep.config.Command",
+			As:                 "podStep.config.As",
+			From: api.ImageStreamTagReference{
+				Name: "podStep.config.From.Name",
+				Tag:  "podStep.config.From.Tag",
+			},
+		},
+	}
+}


### PR DESCRIPTION
This will allow to inject secrets into test step pods. So we can test cloud interaction from test pods without the need to run complex template.

This is needed for openshift on azure work, so we could test cloud api's behaviour in test steps and keep all the logic inside openshift-azure repo, instead of release repo. 

/cc @jim-minter @stevekuznetsov 