### PR TITLE
Allow images to be excluded from promotion, no matter what

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -28,6 +28,8 @@ images:
 promotion:
   additional_images:
     <name>: ''
+  excluded_images:
+  - <name>
   name: ''
   name_prefix: ''
   namespace: ''
@@ -390,6 +392,11 @@ using one tag but many `ImageStream`s.
 Pipeline images are not considered for promotion by default, but you can use this
 field to promote those intermediary images like compiled tests that are not part
 of the normal release for the component but may be useful for other repositories.
+
+## `promotion.excluded_images`
+`excluded_images` is an array of image names that should never be promoted. This
+exclusion is performed on images that were built, but does not prevent images
+specified in `additional_images` from being promoted.
 
 # `resources`
 `resources` configures the resource requests and limits set on build and test

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -211,6 +211,12 @@ type PromotionConfiguration struct {
 	// if specified.
 	NamePrefix string `json:"name_prefix"`
 
+	// ExcludedImages are image names that will not be promoted.
+	// Exclusions are made before additional_images are included.
+	// Use exclusions when you want to build images for testing
+	// but not promote them afterwards.
+	ExcludedImages []string `json:"excluded_images"`
+
 	// AdditionalImages is a mapping of images to promote. The
 	// images will be taken from the pipeline image stream. The
 	// key is the name to promote as and the value is the source

--- a/pkg/steps/promote.go
+++ b/pkg/steps/promote.go
@@ -46,6 +46,10 @@ func (s *promotionStep) Run(ctx context.Context, dry bool) error {
 		tags[tag] = tag
 		names.Insert(tag)
 	}
+	for _, tag := range s.config.ExcludedImages {
+		delete(tags, tag)
+		names.Delete(tag)
+	}
 	for dst, src := range s.config.AdditionalImages {
 		tags[dst] = src
 		names.Insert(dst)


### PR DESCRIPTION
Some test environments may wish to build an image and put it in the
payload for testing, but not promote that image. An example of this
is the new machine-os-content image that will be built for RHCoS -
a few projects like origin and crio need to be able to take the
existing machine-os-content as a prereq, layer on top of it their
test RPMs, and then verify the complete payload as an e2e test (i.e.
test RHCoS with their latest code). Since this image is test only,
we need a clean way to indicate it's not for promotion, but we
want to build it every time we build the payload.

This will also be simpler for folks to reason about than optional,
which was really only for artifact style images that currently
aren't ever tested or added than the payload.

In promotion config, add:

    excluded_images:
    - image-1
    - image-2
    - ...

and the referenced images will never be promoted.

Part of enabling RHCoS content images to be layered during CI
runs so we test kubelet from an origin PR with the OS base image
in the payload.