### PR TITLE
test: Add an optional flag to the api for cluster tests

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -358,6 +358,10 @@ field is only valid in tests that provision a cluster (`openshift_ansible`,
 These are a subset of the profiles found in the
 [`release` repository](https://github.com/openshift/release/tree/master/cluster/test-deploy).
 
+## `tests.*.optional`
+`optional` indicates the test should only be run if the user requests the job
+be executed via a `/test` command.
+
 # `raw_steps`
 `raw_steps` is intended for advanced use of `ci-operator` to build custom execution
 graphs. Contact a CI administrator if a workflow is complex enough to warrant use

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -332,6 +332,11 @@ const (
 // ClusterTestConfiguration describes a test that provisions
 // a cluster and runs a command in it.
 type ClusterTestConfiguration struct {
+	// Optional jobs are not run when unless the user requests
+	// them.
+	Optional bool `json:"optional"`
+	// ClusterProfile identifies the configuration for the job
+	// type.
 	ClusterProfile ClusterProfile `json:"cluster_profile"`
 }
 


### PR DESCRIPTION
We want to auto generate prow jobs that aren't run automatically.
Add `optional` to cluster tests to indicate that they should only
be invoked if the user requests.

Will be followed by a ci-operator-prowgen change to set run_always
and /test all membership based on this flag.