### PR TITLE
Revert "test: Add an optional flag to the api for cluster tests"

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -358,10 +358,6 @@ field is only valid in tests that provision a cluster (`openshift_ansible`,
 These are a subset of the profiles found in the
 [`release` repository](https://github.com/openshift/release/tree/master/cluster/test-deploy).
 
-## `tests.*.optional`
-`optional` indicates the test should only be run if the user requests the job
-be executed via a `/test` command.
-
 # `raw_steps`
 `raw_steps` is intended for advanced use of `ci-operator` to build custom execution
 graphs. Contact a CI administrator if a workflow is complex enough to warrant use

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -332,11 +332,6 @@ const (
 // ClusterTestConfiguration describes a test that provisions
 // a cluster and runs a command in it.
 type ClusterTestConfiguration struct {
-	// Optional jobs are not run when unless the user requests
-	// them.
-	Optional bool `json:"optional"`
-	// ClusterProfile identifies the configuration for the job
-	// type.
 	ClusterProfile ClusterProfile `json:"cluster_profile"`
 }
 


### PR DESCRIPTION
This reverts commit 68dff40e6c01fd18d806ea4089e030f353ca7773.

I'm reverting this until we settle on what the actual supported set we want is.