### PR TITLE
Support extra_refs being passed to jobs and into src build

### DIFF
--- a/pkg/api/job_spec.go
+++ b/pkg/api/job_spec.go
@@ -19,7 +19,8 @@ type JobSpec struct {
 	BuildId   string      `json:"buildid,omitempty"`
 	ProwJobID string      `json:"prowjobid,omitempty"`
 
-	Refs Refs `json:"refs,omitempty"`
+	Refs      *Refs  `json:"refs,omitempty"`
+	ExtraRefs []Refs `json:"extra_refs,omitempty"`
 
 	// rawSpec is the serialized form of the Spec
 	rawSpec string

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -424,7 +424,11 @@ func createStepConfigForTagRefImage(target api.ImageStreamTagReference, jobSpec 
 		target.Namespace = jobSpec.BaseNamespace
 	}
 	if target.Name == "" {
-		target.Name = fmt.Sprintf("%s-test-base", jobSpec.Refs.Repo)
+		if jobSpec.Refs != nil {
+			target.Name = fmt.Sprintf("%s-test-base", jobSpec.Refs.Repo)
+		} else {
+			target.Name = "test-base"
+		}
 	}
 
 	return api.StepConfiguration{

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -32,7 +32,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 				},
 			},
 			jobSpec: &api.JobSpec{
-				Refs: api.Refs{
+				Refs: &api.Refs{
+					Org:  "org",
 					Repo: "repo",
 				},
 				BaseNamespace: "base-1",
@@ -64,7 +65,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 				BinaryBuildCommands: "hi",
 			},
 			jobSpec: &api.JobSpec{
-				Refs: api.Refs{
+				Refs: &api.Refs{
+					Org:  "org",
 					Repo: "repo",
 				},
 				BaseNamespace: "base-1",
@@ -103,7 +105,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 				RpmBuildCommands:    "hello",
 			},
 			jobSpec: &api.JobSpec{
-				Refs: api.Refs{
+				Refs: &api.Refs{
+					Org:  "org",
 					Repo: "repo",
 				},
 				BaseNamespace: "base-1",
@@ -151,7 +154,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 				RpmBuildCommands: "hello",
 			},
 			jobSpec: &api.JobSpec{
-				Refs: api.Refs{
+				Refs: &api.Refs{
+					Org:  "org",
 					Repo: "repo",
 				},
 				BaseNamespace: "base-1",
@@ -194,7 +198,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 				RpmBuildCommands: "hello",
 			},
 			jobSpec: &api.JobSpec{
-				Refs: api.Refs{
+				Refs: &api.Refs{
+					Org:  "org",
 					Repo: "repo",
 				},
 				BaseNamespace: "base-1",
@@ -242,7 +247,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 				},
 			},
 			jobSpec: &api.JobSpec{
-				Refs: api.Refs{
+				Refs: &api.Refs{
+					Org:  "org",
 					Repo: "repo",
 				},
 				BaseNamespace: "base-1",
@@ -290,7 +296,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 				},
 			},
 			jobSpec: &api.JobSpec{
-				Refs: api.Refs{
+				Refs: &api.Refs{
+					Org:  "org",
 					Repo: "repo",
 				},
 				BaseNamespace: "base-1",

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"log"
 
 	buildapi "github.com/openshift/api/build/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
@@ -23,6 +24,10 @@ func (s *gitSourceStep) Inputs(ctx context.Context, dry bool) (api.InputDefiniti
 }
 
 func (s *gitSourceStep) Run(ctx context.Context, dry bool) error {
+	if s.jobSpec.Refs == nil {
+		log.Printf("Nothing to build source image from, no refs")
+		return nil
+	}
 	return handleBuild(s.buildClient, buildFromSource(s.jobSpec, "", api.PipelineImageStreamTagReferenceRoot, buildapi.BuildSource{
 		Type:       buildapi.BuildSourceGit,
 		ContextDir: s.config.ContextDir,

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -66,16 +66,18 @@ func (s *projectDirectoryImageBuildStep) Run(ctx context.Context, dry bool) erro
 	} {
 		labels[key] = ""
 	}
-	if len(s.jobSpec.Refs.Pulls) == 0 {
-		labels["vcs-type"] = "git"
-		labels["vcs-ref"] = s.jobSpec.Refs.BaseSHA
-		labels["io.openshift.build.commit.id"] = s.jobSpec.Refs.BaseSHA
-		labels["io.openshift.build.commit.ref"] = s.jobSpec.Refs.BaseRef
-		if len(s.jobSpec.Refs.Org) > 0 && len(s.jobSpec.Refs.Repo) > 0 {
-			labels["vcs-url"] = fmt.Sprintf("https://github.com/%s/%s", s.jobSpec.Refs.Org, s.jobSpec.Refs.Repo)
+	if refs := s.jobSpec.Refs; refs != nil {
+		if len(refs.Pulls) == 0 {
+			labels["vcs-type"] = "git"
+			labels["vcs-ref"] = refs.BaseSHA
+			labels["io.openshift.build.commit.id"] = refs.BaseSHA
+			labels["io.openshift.build.commit.ref"] = refs.BaseRef
+			labels["vcs-url"] = fmt.Sprintf("https://github.com/%s/%s", refs.Org, refs.Repo)
 			labels["io.openshift.build.source-location"] = labels["vcs-url"]
+			labels["io.openshift.build.source-context-dir"] = s.config.ContextDir
 		}
-		labels["io.openshift.build.source-context-dir"] = s.config.ContextDir
+		// TODO: we should consider setting enough info for a caller to reconstruct pulls to support
+		// oc adm release info tooling
 	}
 
 	images := buildInputsFromStep(s.config.Inputs)

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -383,10 +383,13 @@ func (s *rpmServerStep) rpmRepoURL() (string, error) {
 }
 
 func (s *rpmServerStep) Provides() (api.ParameterMap, api.StepLink) {
-	rpmByOrgAndRepo := strings.Replace(fmt.Sprintf("RPM_REPO_%s_%s", strings.ToUpper(s.jobSpec.Refs.Org), strings.ToUpper(s.jobSpec.Refs.Repo)), "-", "_", -1)
-	return api.ParameterMap{
-		rpmByOrgAndRepo: s.rpmRepoURL,
-	}, api.RPMRepoLink()
+	if s.jobSpec.Refs != nil {
+		rpmByOrgAndRepo := strings.Replace(fmt.Sprintf("RPM_REPO_%s_%s", strings.ToUpper(s.jobSpec.Refs.Org), strings.ToUpper(s.jobSpec.Refs.Repo)), "-", "_", -1)
+		return api.ParameterMap{
+			rpmByOrgAndRepo: s.rpmRepoURL,
+		}, api.RPMRepoLink()
+	}
+	return nil, nil
 }
 
 func (s *rpmServerStep) Name() string { return "[serve:rpms]" }

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -97,14 +97,22 @@ func (s *sourceStep) Run(ctx context.Context, dry bool) error {
 		s.resources,
 	)
 
-	refs := s.jobSpec.Refs
-	refs.PathAlias = s.config.PathAlias
+	var refs []interface{}
+	// periodic jobs may have no refs to clone
+	if s.jobSpec.Refs != nil {
+		ref := s.jobSpec.Refs
+		ref.PathAlias = s.config.PathAlias
+		refs = append(refs, ref)
+	}
+	for _, ref := range s.jobSpec.ExtraRefs {
+		refs = append(refs, ref)
+	}
 	optionsSpec := map[string]interface{}{
 		"src_root":       gopath,
 		"log":            "/dev/null",
 		"git_user_name":  "ci-robot",
 		"git_user_email": "ci-robot@openshift.io",
-		"refs":           []interface{}{refs},
+		"refs":           refs,
 	}
 	optionsJSON, err := json.Marshal(optionsSpec)
 	if err != nil {


### PR DESCRIPTION
extra_refs was silently ignored. Display it in metadata.json, in the
log message at the start of the run, and pass it to the source build
as part of CLONEREFS_OPTIONS. Skip adding the main repo when it is
empty (as it can be with periodics).

Fixes #258