### PR TITLE
api: Support a `memory_backed_volume` for tests that need fast IO

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -318,6 +318,14 @@ of the images in the pipeline.
 ## `tests.container.from`
 `from` is the pipeline image tag that this test will be run on.
 
+## `tests.container.memory_backed_volume`
+`memory_backed_volume` if specified mounts a tmpfs (filesystem in RAM) at
+`/tmp/volume` with the specified size (required).
+
+## `tests.container.memory_backed_volume.size`
+`size` is the required quantity of the volume to create in bytes. Use Kubernetes
+resource quantity semantics (e.g. `1Gi` or `500M`).
+
 # `tests.secret` 
 
 `Secret` field enables users to mount a secret inside test container.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -208,6 +208,11 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 	typeCount := 0
 	if testConfig := test.ContainerTestConfiguration; testConfig != nil {
 		typeCount++
+		if testConfig.MemoryBackedVolume != nil {
+			if _, err := resource.ParseQuantity(testConfig.MemoryBackedVolume.Size); err != nil {
+				validationErrors = append(validationErrors, fmt.Errorf("%s.memory_backed_volume: 'size' must be a Kubernetes quantity: %v", fieldRoot, err))
+			}
+		}
 		if len(testConfig.From) == 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: 'from' is required", fieldRoot))
 		}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -82,6 +82,38 @@ func TestValidateTests(t *testing.T) {
 			expectedValid: false,
 		},
 		{
+			id: "test valid memory backed volume",
+			tests: []TestStepConfiguration{
+				{
+					As:       "test",
+					Commands: "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{
+						From: "ignored",
+						MemoryBackedVolume: &MemoryBackedVolume{
+							Size: "1Gi",
+						},
+					},
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			id: "test invalid memory backed volume",
+			tests: []TestStepConfiguration{
+				{
+					As:       "test",
+					Commands: "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{
+						From: "ignored",
+						MemoryBackedVolume: &MemoryBackedVolume{
+							Size: "1GG", // not valid
+						},
+					},
+				},
+			},
+			expectedValid: false,
+		},
+		{
 			id: "test with duplicated `as`",
 			tests: []TestStepConfiguration{
 				{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -312,12 +312,25 @@ type Secret struct {
 	MountPath string `json:"mount_path"`
 }
 
+// MemoryBackedVolume describes a tmpfs (memory backed volume)
+// that will be mounted into a test container at /tmp/volume.
+// Use with tests that need extremely fast disk, such as those
+// that run an etcd server or other IO-intensive workload.
+type MemoryBackedVolume struct {
+	// Size is the requested size of the volume as a Kubernetes
+	// quantity, i.e. "1Gi" or "500M"
+	Size string `json:"size"`
+}
+
 // ContainerTestConfiguration describes a test that runs a
 // command in one of the previously built images.
 type ContainerTestConfiguration struct {
 	// From is the image stream tag in the pipeline to run this
 	// command in.
 	From PipelineImageStreamTagReference `json:"from"`
+	// MemoryBackedVolume mounts a volume of the specified size into
+	// the container at /tmp/volume.
+	MemoryBackedVolume *MemoryBackedVolume `json:"memory_backed_volume"`
 }
 
 // ClusterProfile is the name of a set of input variables


### PR DESCRIPTION
Some tests like the OpenShift integration tests are extremely IO
intensive in a way that can disrupt other jobs. Allow these jobs to
request a memory backed filesystem to be mounted into the test
container at a predefined location.

```
tests:
- as: foo
  command: bar
  container:
    memory_backed_volume:
      size: 1Gi
```