### PR TITLE
If cancelled, promotion was still being invoked

### DIFF
--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -45,6 +45,7 @@ func Run(ctx context.Context, graph []*api.StepNode, dry bool) (*junit.TestSuite
 	for {
 		select {
 		case <-ctxDone:
+			errors = append(errors, fmt.Errorf("execution cancelled"))
 			suite.Duration = time.Now().Sub(start).Seconds()
 			return suites, aggregateError(errors)
 		case out := <-results:


### PR DESCRIPTION
The Run method, when cancelled by a context interrupt, would not
return an error if no error had occurred during step execution.
This caused promotion to think that the run was successful, and
we attempt to promote things we haven't created yet. This could
result in an older image being promoted by accident.