### PR TITLE
Retry promotion longer

### DIFF
--- a/pkg/steps/promote.go
+++ b/pkg/steps/promote.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
 	imageapi "github.com/openshift/api/image/v1"
@@ -39,6 +41,13 @@ func (s *promotionStep) Inputs(ctx context.Context, dry bool) (api.InputDefiniti
 	return nil, nil
 }
 
+var promotionRetry = wait.Backoff{
+	Steps:    20,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.2,
+	Jitter:   0.1,
+}
+
 func (s *promotionStep) Run(ctx context.Context, dry bool) error {
 	tags := make(map[string]string)
 	names := sets.NewString()
@@ -63,7 +72,7 @@ func (s *promotionStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	if len(s.config.Name) > 0 {
-		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return retry.RetryOnConflict(promotionRetry, func() error {
 			is, err := s.dstClient.ImageStreams(s.config.Namespace).Get(s.config.Name, meta.GetOptions{})
 			if errors.IsNotFound(err) {
 				is, err = s.dstClient.ImageStreams(s.config.Namespace).Create(&imageapi.ImageStream{
@@ -113,7 +122,7 @@ func (s *promotionStep) Run(ctx context.Context, dry bool) error {
 
 		name := fmt.Sprintf("%s%s", s.config.NamePrefix, dst)
 
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := retry.RetryOnConflict(promotionRetry, func() error {
 			_, err := s.dstClient.ImageStreams(s.config.Namespace).Get(name, meta.GetOptions{})
 			if errors.IsNotFound(err) {
 				_, err = s.dstClient.ImageStreams(s.config.Namespace).Create(&imageapi.ImageStream{


### PR DESCRIPTION
While testing full release builds I was able to cause a bunch of
builds to line up and attempt to promote at the same time (12)
which exceeded our default retry window of 5. Increase the retry
count and add a slight backoff so that even highly parallel
rebuilds have a good chance of completing.