### PR TITLE
Avoid touching files already in the src image and causing a copy up

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -49,7 +49,7 @@ func sourceDockerfile(fromTag api.PipelineImageStreamTagReference, pathAlias str
 	return fmt.Sprintf(`
 FROM %s:%s
 ADD ./app.binary /clonerefs
-RUN umask 0002 && /clonerefs && chmod g+xw -R %s/src
+RUN umask 0002 && /clonerefs && find %s/src -type d -not -perm -0775 | xargs chmod g+xw
 WORKDIR %s/src/%s/
 ENV GOPATH=%s
 RUN git submodule update --init


### PR DESCRIPTION
In overlayfs, changing file attributes causes the entire file to be
copied up. When the origin master src cache image is used (which has
/go/src/%/.git prepopulated) chmod g+wx -R caused every file in the
directory to be changed, which meant the top layer for origin src
images ended up being as big as the repo, about 1gb.

This changes only directories that don't already have the correct
permissions, which is the original intent of the change.