### PR TITLE
We need to be able to run tests against many releases

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -11,8 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-var originReleaseTagRegexp = regexp.MustCompile(`^origin-v\d+\.\d+$`)
-
 // Validate validates all the configuration's values.
 func (config *ReleaseBuildConfiguration) Validate() error {
 	var validationErrors []error
@@ -254,8 +252,8 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 	if typeCount == 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("%s has no type, you may want to specify 'container' for a container based test", fieldRoot))
 	} else if typeCount == 1 {
-		if needsReleaseRpms && (release == nil || !originReleaseTagRegexp.MatchString(release.Name)) {
-			validationErrors = append(validationErrors, fmt.Errorf("%s requires an 'origin' release in 'tag_specification'", fieldRoot))
+		if needsReleaseRpms && release == nil {
+			validationErrors = append(validationErrors, fmt.Errorf("%s requires a release in 'tag_specification'", fieldRoot))
 		}
 	} else if typeCount > 1 {
 		validationErrors = append(validationErrors, fmt.Errorf("%s has more than one type", fieldRoot))

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -171,7 +171,8 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			release: &ReleaseTagConfiguration{},
+			release:       &ReleaseTagConfiguration{},
+			expectedValid: true,
 		},
 		{
 			id: "with release",


### PR DESCRIPTION
'origin' is not a magic constant, remove the check for a known type
of release.

Blocks moving content to ocp namespace in preparation for 4.0 release
(openshift/origin-v4.0 is going to be the external location)