### PR TITLE
Disable defaulting on promotion

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -121,9 +121,9 @@ development workflow would use. The --override file will override fields
 defined in the config file, such as base images and the release tag configuration.
 
 After a successful build the --promote will tag each built image (in "images")
-to the image stream(s) identified by the "promotion" config, which defaults to
-the same image stream as the release configuration. You may add additional
-images to promote and their target names via the "additional_images" map.
+to the image stream(s) identified by the "promotion" config. You may add
+additional images to promote and their target names via the "additional_images"
+map.
 `
 
 func main() {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -213,17 +213,6 @@ func checkForFullyQualifiedStep(step api.Step, params *steps.DeferredParameters)
 func promotionDefaults(configSpec *api.ReleaseBuildConfiguration) (*api.PromotionConfiguration, error) {
 	config := configSpec.PromotionConfiguration
 	if config == nil {
-		config = &api.PromotionConfiguration{}
-	}
-	if len(config.Tag) == 0 && len(config.Name) == 0 {
-		if input := configSpec.ReleaseTagConfiguration; input != nil {
-			config.Namespace = input.Namespace
-			config.Name = input.Name
-			config.NamePrefix = input.NamePrefix
-			config.Tag = input.Tag
-		}
-	}
-	if config == nil {
 		return nil, fmt.Errorf("cannot promote images, no promotion or release tag configuration defined")
 	}
 	return config, nil


### PR DESCRIPTION
Users must explicitly request promotion now.  All openshift/release jobs have been updated.

This is paired with https://github.com/openshift/ci-operator-prowgen/pull/86 but that one can merge first.