### PR TITLE
base: Allow base_images to be defaulted from tag_specification

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -152,7 +152,9 @@ base_images:
 ```
 
 The key in this mapping is the name that can be used in `"from"` fields elsewhere
-in the configuration to refer to this image.
+in the configuration to refer to this image. If `tag_specification` is set, you
+may omit `cluster`, `namespace`, and `name` and they will be defaulted from the
+`tag_specification`.
 
 # `base_rpm_images`
 `base_rpm_images` are images that will have the RPMs that are built from the

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/openshift/ci-operator/pkg/api"
+	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func addCloneRefs(cfg *api.SourceStepConfiguration) *api.SourceStepConfiguration {
@@ -280,6 +281,67 @@ func TestStepConfigsForBuild(t *testing.T) {
 			}},
 		},
 		{
+			name: "implicit base image from release configuration",
+			input: &api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					BuildRootImage: &api.BuildRootImageConfiguration{
+						ImageStreamTagReference: &api.ImageStreamTagReference{Tag: "manual"},
+					},
+					ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+						Namespace: "test",
+						Name:      "other",
+					},
+					BaseImages: map[string]api.ImageStreamTagReference{
+						"name": {
+							Tag: "tag",
+						},
+					},
+				},
+			},
+			jobSpec: &api.JobSpec{
+				Refs: &api.Refs{
+					Org:  "org",
+					Repo: "repo",
+				},
+				BaseNamespace: "base-1",
+			},
+			output: []api.StepConfiguration{
+				{
+					InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
+						BaseImage: api.ImageStreamTagReference{
+							Namespace: "base-1",
+							Name:      "repo-test-base",
+							Tag:       "manual",
+						},
+						To: api.PipelineImageStreamTagReferenceRoot,
+					},
+				},
+				{
+					SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
+						From: api.PipelineImageStreamTagReferenceRoot,
+						To:   api.PipelineImageStreamTagReferenceSource,
+					}),
+				},
+				{
+					InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
+						BaseImage: api.ImageStreamTagReference{
+							Namespace: "test",
+							Name:      "other",
+							Tag:       "tag",
+							As:        "name",
+						},
+						To: api.PipelineImageStreamTagReference("name"),
+					},
+				},
+				{
+					ReleaseImagesTagStepConfiguration: &api.ReleaseTagConfiguration{
+						Namespace: "test",
+						Name:      "other",
+					},
+				},
+			},
+		},
+		{
 			name: "rpm base image requested",
 			input: &api.ReleaseBuildConfiguration{
 				InputConfiguration: api.InputConfiguration{
@@ -338,6 +400,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			if configs := stepConfigsForBuild(testCase.input, testCase.jobSpec); !stepListsEqual(configs, testCase.output) {
+				t.Logf("%s", diff.ObjectReflectDiff(testCase.output, configs))
 				t.Errorf("incorrect defaulted step configurations,\n\tgot:\n%s\n\texpected:\n%s", formatSteps(configs), formatSteps(testCase.output))
 			}
 		})


### PR DESCRIPTION
While testing image builds with ci-operator it was difficult to
take a bunch of ci jobs and test a complete configuration that has
a different base image or source location. One difficulty was that
we had redundant info in almost all ci-operator job definitions
from the base image that comes from the tag definition. This
change simplifies base images a bit when pulling from a common
root by allowing the cluster, namespace, and name field for
base_images and base_rpm_images to default to the tag specification.

E.g.:

```
tag_specification:
  name: '4.0'
  namespace: ocp
base_images:
  base:
    name: '4.0'
    namespace: ocp
    tag: base
```

can be reduced to

```
tag_specification:
  name: '4.0'
  namespace: ocp
base_images:
  base:
    tag: base
```

This reduces some boilerplate and seems internally consistent (if you have a
tag specification it defines one of your inputs - pulling from the same pool
for base images also seems reasonable).