### PR TITLE
add abiility to dump openshift docker build strategy logs even if bui…

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -115,19 +115,19 @@ func FromConfig(
 			}
 			step = steps.InputImageTagStep(*rawStep.InputImageTagStepConfiguration, srcClient, imageClient, jobSpec)
 		} else if rawStep.PipelineImageCacheStepConfiguration != nil {
-			step = steps.PipelineImageCacheStep(*rawStep.PipelineImageCacheStepConfiguration, config.Resources, buildClient, imageClient, jobSpec)
+			step = steps.PipelineImageCacheStep(*rawStep.PipelineImageCacheStepConfiguration, config.Resources, buildClient, imageClient, artifactDir, jobSpec)
 		} else if rawStep.SourceStepConfiguration != nil {
 			srcClient, err := anonymousClusterImageStreamClient(imageClient, clusterConfig, rawStep.SourceStepConfiguration.ClonerefsImage.Cluster)
 			if err != nil {
 				return nil, nil, fmt.Errorf("unable to access image stream tag on remote cluster: %v", err)
 			}
-			step = steps.SourceStep(*rawStep.SourceStepConfiguration, config.Resources, buildClient, srcClient, imageClient, jobSpec)
+			step = steps.SourceStep(*rawStep.SourceStepConfiguration, config.Resources, buildClient, srcClient, imageClient, artifactDir, jobSpec)
 		} else if rawStep.ProjectDirectoryImageBuildStepConfiguration != nil {
-			step = steps.ProjectDirectoryImageBuildStep(*rawStep.ProjectDirectoryImageBuildStepConfiguration, config.Resources, buildClient, imageClient, imageClient, jobSpec)
+			step = steps.ProjectDirectoryImageBuildStep(*rawStep.ProjectDirectoryImageBuildStepConfiguration, config.Resources, buildClient, imageClient, imageClient, artifactDir, jobSpec)
 		} else if rawStep.ProjectDirectoryImageBuildInputs != nil {
-			step = steps.GitSourceStep(*rawStep.ProjectDirectoryImageBuildInputs, config.Resources, buildClient, imageClient, jobSpec)
+			step = steps.GitSourceStep(*rawStep.ProjectDirectoryImageBuildInputs, config.Resources, buildClient, imageClient, artifactDir, jobSpec)
 		} else if rawStep.RPMImageInjectionStepConfiguration != nil {
-			step = steps.RPMImageInjectionStep(*rawStep.RPMImageInjectionStepConfiguration, config.Resources, buildClient, routeGetter, imageClient, jobSpec)
+			step = steps.RPMImageInjectionStep(*rawStep.RPMImageInjectionStepConfiguration, config.Resources, buildClient, routeGetter, imageClient, artifactDir, jobSpec)
 		} else if rawStep.RPMServeStepConfiguration != nil {
 			step = steps.RPMServerStep(*rawStep.RPMServeStepConfiguration, deploymentGetter, routeGetter, serviceGetter, imageClient, jobSpec)
 		} else if rawStep.OutputImageTagStepConfiguration != nil {

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 
+	buildapi "github.com/openshift/api/build/v1"
 	templateapi "github.com/openshift/api/template/v1"
 
 	"github.com/openshift/ci-operator/pkg/junit"
@@ -691,6 +692,35 @@ func gatherContainerLogsOutput(podClient PodClient, artifactDir, namespace, podN
 		}
 	}
 	return kerrors.NewAggregate(validationErrors)
+}
+
+// for gathering successful build logs to the artifacts, there is no way to augment the pod spec
+// created by the build controller to add the artifacts container; this method cherry picks elements
+// from downloadArtifacts and gatherContainerLogsOutput and munges them in conjunction with the build
+// api logging capabilities; also, without needing to inject an artifacts container, some of the complexities
+// around download/copy from the artifacts container's volume mount and multiple pods are avoided.
+func gatherSuccessfulBuildLog(buildClient BuildClient, artifactDir, namespace, buildName string) error {
+	// adding a subdir to the artifactDir path similar to downloadArtifacts adding the container-logs subdir
+	dir := filepath.Join(artifactDir, "openshift-docker-build-strategy-logs")
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("unable to create directory %s: %v", dir, err)
+	}
+	file, err := os.Create(fmt.Sprintf("%s/%s.log.gz", dir, buildName))
+	if err != nil {
+		return fmt.Errorf("Cannot create file: %v", err)
+	}
+	defer file.Close()
+	w := gzip.NewWriter(file)
+	defer w.Close()
+	if rc, err := buildClient.Logs(namespace, buildName, &buildapi.BuildLogOptions{}); err == nil {
+		defer rc.Close()
+		if _, err := io.Copy(w, rc); err != nil {
+			return fmt.Errorf("error: Unable to copy log output from pod container %s: %v", buildName, err)
+		}
+	} else {
+		return fmt.Errorf("error: Unable to retrieve logs for build %s: %v", buildName, err)
+	}
+	return nil
 }
 
 func getContainerStatuses(pod *coreapi.Pod) []coreapi.ContainerStatus {

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -16,6 +16,7 @@ type gitSourceStep struct {
 	resources   api.ResourceConfiguration
 	imageClient imageclientset.ImageV1Interface
 	buildClient BuildClient
+	artifactDir string
 	jobSpec     *api.JobSpec
 }
 
@@ -35,7 +36,7 @@ func (s *gitSourceStep) Run(ctx context.Context, dry bool) error {
 			URI: fmt.Sprintf("https://github.com/%s/%s.git", s.jobSpec.Refs.Org, s.jobSpec.Refs.Repo),
 			Ref: s.jobSpec.Refs.BaseRef,
 		},
-	}, s.config.DockerfilePath, s.resources), dry)
+	}, s.config.DockerfilePath, s.resources), dry, s.artifactDir)
 }
 
 func (s *gitSourceStep) Done() (bool, error) {
@@ -59,12 +60,13 @@ func (s *gitSourceStep) Provides() (api.ParameterMap, api.StepLink) {
 }
 
 // GitSourceStep returns gitSourceStep that holds all the required information to create a build from a git source.
-func GitSourceStep(config api.ProjectDirectoryImageBuildInputs, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, jobSpec *api.JobSpec) api.Step {
+func GitSourceStep(config api.ProjectDirectoryImageBuildInputs, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return &gitSourceStep{
 		config:      config,
 		resources:   resources,
 		buildClient: buildClient,
 		imageClient: imageClient,
+		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 	}
 }

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -22,6 +22,7 @@ type pipelineImageCacheStep struct {
 	resources   api.ResourceConfiguration
 	buildClient BuildClient
 	imageClient imageclientset.ImageV1Interface
+	artifactDir string
 	jobSpec     *api.JobSpec
 }
 
@@ -39,7 +40,7 @@ func (s *pipelineImageCacheStep) Run(ctx context.Context, dry bool) error {
 		},
 		"",
 		s.resources,
-	), dry)
+	), dry, s.artifactDir)
 }
 
 func (s *pipelineImageCacheStep) Done() (bool, error) {
@@ -83,12 +84,13 @@ func (s *pipelineImageCacheStep) Description() string {
 	return fmt.Sprintf("Store build results into a layer on top of %s and save as %s", s.config.From, s.config.To)
 }
 
-func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, jobSpec *api.JobSpec) api.Step {
+func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return &pipelineImageCacheStep{
 		config:      config,
 		resources:   resources,
 		buildClient: buildClient,
 		imageClient: imageClient,
+		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 	}
 }

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -21,6 +21,7 @@ type projectDirectoryImageBuildStep struct {
 	imageClient imageclientset.ImageStreamsGetter
 	istClient   imageclientset.ImageStreamTagsGetter
 	jobSpec     *api.JobSpec
+	artifactDir string
 }
 
 func (s *projectDirectoryImageBuildStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -108,7 +109,7 @@ func (s *projectDirectoryImageBuildStep) Run(ctx context.Context, dry bool) erro
 			Value: v,
 		})
 	}
-	return handleBuild(s.buildClient, build, dry)
+	return handleBuild(s.buildClient, build, dry, s.artifactDir)
 }
 
 func (s *projectDirectoryImageBuildStep) Done() (bool, error) {
@@ -161,13 +162,14 @@ func (s *projectDirectoryImageBuildStep) Description() string {
 	return fmt.Sprintf("Build image %s from the repository", s.config.To)
 }
 
-func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageStreamsGetter, istClient imageclientset.ImageStreamTagsGetter, jobSpec *api.JobSpec) api.Step {
+func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageStreamsGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return &projectDirectoryImageBuildStep{
 		config:      config,
 		resources:   resources,
 		buildClient: buildClient,
 		imageClient: imageClient,
 		istClient:   istClient,
+		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 	}
 }

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -23,6 +23,7 @@ type rpmImageInjectionStep struct {
 	buildClient BuildClient
 	routeClient routeclientset.RoutesGetter
 	istClient   imageclientset.ImageStreamTagsGetter
+	artifactDir string
 	jobSpec     *api.JobSpec
 }
 
@@ -50,7 +51,7 @@ func (s *rpmImageInjectionStep) Run(ctx context.Context, dry bool) error {
 		},
 		"",
 		s.resources,
-	), dry)
+	), dry, s.artifactDir)
 }
 
 func (s *rpmImageInjectionStep) Done() (bool, error) {
@@ -75,13 +76,14 @@ func (s *rpmImageInjectionStep) Description() string {
 	return "Inject an RPM repository that will point at the RPM server"
 }
 
-func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, routeClient routeclientset.RoutesGetter, istClient imageclientset.ImageStreamTagsGetter, jobSpec *api.JobSpec) api.Step {
+func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, routeClient routeclientset.RoutesGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return &rpmImageInjectionStep{
 		config:      config,
 		resources:   resources,
 		buildClient: buildClient,
 		routeClient: routeClient,
 		istClient:   istClient,
+		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 	}
 }

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -65,6 +65,7 @@ type sourceStep struct {
 	buildClient        BuildClient
 	imageClient        imageclientset.ImageV1Interface
 	clonerefsSrcClient imageclientset.ImageV1Interface
+	artifactDir        string
 	jobSpec            *api.JobSpec
 }
 
@@ -127,7 +128,7 @@ func (s *sourceStep) Run(ctx context.Context, dry bool) error {
 		coreapi.EnvVar{Name: "CLONEREFS_OPTIONS", Value: string(optionsJSON)},
 	)
 
-	return handleBuild(s.buildClient, build, dry)
+	return handleBuild(s.buildClient, build, dry, s.artifactDir)
 }
 
 func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStreamTagReference, source buildapi.BuildSource, dockerfilePath string, resources api.ResourceConfiguration) *buildapi.Build {
@@ -223,7 +224,7 @@ func buildInputsFromStep(inputs map[string]api.ImageBuildInputs) []buildapi.Imag
 	return refs
 }
 
-func handleBuild(buildClient BuildClient, build *buildapi.Build, dry bool) error {
+func handleBuild(buildClient BuildClient, build *buildapi.Build, dry bool, artifactDir string) error {
 	if dry {
 		buildJSON, err := json.MarshalIndent(build, "", "  ")
 		if err != nil {
@@ -254,7 +255,16 @@ func handleBuild(buildClient BuildClient, build *buildapi.Build, dry bool) error
 			return fmt.Errorf("could not create build %s: %v", build.Name, err)
 		}
 	}
-	return waitForBuild(buildClient, build.Namespace, build.Name)
+	err := waitForBuild(buildClient, build.Namespace, build.Name)
+	if err == nil && len(artifactDir) > 0 {
+		if err := gatherSuccessfulBuildLog(buildClient, artifactDir, build.Namespace, build.Name); err != nil {
+			// log error but do not fail successful build
+			log.Printf("problem gathering successful build %s logs into artifacts: %v", build.Name, err)
+		}
+	}
+	// this will still be the err from waitForBuild
+	return err
+
 }
 
 func isInfraReason(reason buildapi.StatusReason) bool {
@@ -494,13 +504,14 @@ func (s *sourceStep) Description() string {
 	return fmt.Sprintf("Clone the correct source code into an image and tag it as %s", s.config.To)
 }
 
-func SourceStep(config api.SourceStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, clonerefsSrcClient imageclientset.ImageV1Interface, imageClient imageclientset.ImageV1Interface, jobSpec *api.JobSpec) api.Step {
+func SourceStep(config api.SourceStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, clonerefsSrcClient imageclientset.ImageV1Interface, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return &sourceStep{
 		config:             config,
 		resources:          resources,
 		buildClient:        buildClient,
 		imageClient:        imageClient,
 		clonerefsSrcClient: clonerefsSrcClient,
+		artifactDir:        artifactDir,
 		jobSpec:            jobSpec,
 	}
 }


### PR DESCRIPTION
…ld succeeds

/assign @stevekuznetsov 

per our quick confab on slack Steve

was able to test locally after logging into api.ci and creating a test project 

Admittedly, I took the path of least resistance wrt having to add the flag to those different ci-operator build types.  Did not see a ready made path to store the config in one place and have it leveraged by everybody.