### PR TITLE
source: Periodic jobs may have nil refs

### DIFF
--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -75,7 +75,7 @@ func TestValidateTests(t *testing.T) {
 			id: "test without `commands`",
 			tests: []TestStepConfiguration{
 				{
-					As: "test",
+					As:                         "test",
 					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
 				},
 			},
@@ -142,7 +142,7 @@ func TestValidateTests(t *testing.T) {
 			id: "invalid cluster profile",
 			tests: []TestStepConfiguration{
 				{
-					As: "test",
+					As:                                       "test",
 					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{},
 				},
 			},
@@ -192,7 +192,7 @@ func TestValidateTests(t *testing.T) {
 			id: "invalid secret mountPath",
 			tests: []TestStepConfiguration{
 				{
-					As: "test",
+					As:                                       "test",
 					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{},
 					Secret: Secret{
 						Name:      "secret",
@@ -206,7 +206,7 @@ func TestValidateTests(t *testing.T) {
 			id: "invalid secret name",
 			tests: []TestStepConfiguration{
 				{
-					As: "test",
+					As:                                       "test",
 					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{},
 					Secret: Secret{
 						Name:      "secret_test",

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -42,9 +42,12 @@ var (
 )
 
 func sourceDockerfile(fromTag api.PipelineImageStreamTagReference, pathAlias string, job *api.JobSpec) string {
-	workingDir := fmt.Sprintf("github.com/%s/%s", job.Refs.Org, job.Refs.Repo)
-	if len(pathAlias) > 0 {
-		workingDir = pathAlias
+	workingDir := pathAlias
+	if len(workingDir) == 0 && job.Refs != nil {
+		workingDir = fmt.Sprintf("github.com/%s/%s", job.Refs.Org, job.Refs.Repo)
+	}
+	if len(workingDir) == 0 && len(job.ExtraRefs) > 0 {
+		workingDir = fmt.Sprintf("github.com/%s/%s", job.ExtraRefs[0].Org, job.ExtraRefs[0].Repo)
 	}
 	return fmt.Sprintf(`
 FROM %s:%s
@@ -167,11 +170,11 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 				Strategy: buildapi.BuildStrategy{
 					Type: buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{
-						DockerfilePath: dockerfilePath,
-						From:           from,
-						ForcePull:      true,
-						NoCache:        true,
-						Env:            []coreapi.EnvVar{},
+						DockerfilePath:          dockerfilePath,
+						From:                    from,
+						ForcePull:               true,
+						NoCache:                 true,
+						Env:                     []coreapi.EnvVar{},
 						ImageOptimizationPolicy: &layer,
 					},
 				},


### PR DESCRIPTION
We should build source from the first available repo or default to
/go if necessary.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/periodic-ci-origin-conformance-k8s/231/