### PR TITLE
Make canonical go repository omitempty

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -36,7 +36,7 @@ type ReleaseBuildConfiguration struct {
 	// the desired location of the contents of this repository in
 	// Go. If specified the location of the repository we are
 	// cloning from is ignored.
-	CanonicalGoRepository string `json:"canonical_go_repository"`
+	CanonicalGoRepository string `json:"canonical_go_repository,omitempty"`
 
 	// Images describes the images that are built
 	// baseImage the project as part of the release


### PR DESCRIPTION
I'm not sure why this was not present in https://github.com/openshift/ci-operator/pull/277, but the field really looks optional (and many existing configs do not set it). Noticed this while working on https://github.com/openshift/ci-operator-prowgen/pull/98/

/cc @stevekuznetsov