### PR TITLE
Move release related code into a consistent spot

### DIFF
--- a/pkg/api/parameters.go
+++ b/pkg/api/parameters.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+type DeferredParameters struct {
+	lock   sync.Mutex
+	fns    ParameterMap
+	values map[string]string
+	links  map[string][]StepLink
+}
+
+func NewDeferredParameters() *DeferredParameters {
+	return &DeferredParameters{
+		fns:    make(ParameterMap),
+		values: make(map[string]string),
+		links:  make(map[string][]StepLink),
+	}
+}
+
+func (p *DeferredParameters) Map() (map[string]string, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	m := make(map[string]string)
+	for k, fn := range p.fns {
+		if v, ok := p.values[k]; ok {
+			m[k] = v
+			continue
+		}
+		v, err := fn()
+		if err != nil {
+			return nil, fmt.Errorf("could not lazily evaluate deferred parameter: %v", err)
+		}
+		p.values[k] = v
+		m[k] = v
+	}
+	return m, nil
+}
+
+func (p *DeferredParameters) Set(name, value string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if _, ok := p.fns[name]; ok {
+		return
+	}
+	if _, ok := p.values[name]; ok {
+		return
+	}
+	p.values[name] = value
+}
+
+func (p *DeferredParameters) Add(name string, link StepLink, fn func() (string, error)) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.fns[name] = fn
+	if link != nil {
+		p.links[name] = []StepLink{link}
+	}
+}
+
+func (p *DeferredParameters) Has(name string) bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	_, ok := p.fns[name]
+	if ok {
+		return true
+	}
+	_, ok = os.LookupEnv(name)
+	return ok
+}
+
+func (p *DeferredParameters) Links(name string) []StepLink {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if _, ok := os.LookupEnv(name); ok {
+		return nil
+	}
+	return p.links[name]
+}
+
+func (p *DeferredParameters) AllLinks() []StepLink {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	var links []StepLink
+	for name, v := range p.links {
+		if _, ok := os.LookupEnv(name); ok {
+			continue
+		}
+		links = append(links, v...)
+	}
+	return links
+}
+
+func (p *DeferredParameters) Get(name string) (string, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if value, ok := p.values[name]; ok {
+		return value, nil
+	}
+	if value, ok := os.LookupEnv(name); ok {
+		p.values[name] = value
+		return value, nil
+	}
+	if fn, ok := p.fns[name]; ok {
+		value, err := fn()
+		if err != nil {
+			return "", fmt.Errorf("could not lazily evaluate deferred parameter: %v", err)
+		}
+		p.values[name] = value
+		return value, nil
+	}
+	return "", nil
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -529,4 +529,6 @@ const (
 	RPMServeLocation = "/srv/repo"
 
 	StableImageStream = "stable"
+
+	ComponentFormatReplacement = "${component}"
 )

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -37,12 +37,12 @@ func (s *assembleReleaseStep) Run(ctx context.Context, dry bool) error {
 	if err != nil {
 		return fmt.Errorf("could not resolve stable imagestream: %v", err)
 	}
-	cvo, ok := resolvePullSpec(stable, "cluster-version-operator")
+	cvo, ok := resolvePullSpec(stable, "cluster-version-operator", true)
 	if !ok {
 		log.Printf("No release image necessary, stable image stream does not include a cluster-version-operator image")
 		return nil
 	}
-	if _, ok := resolvePullSpec(stable, "cli"); !ok {
+	if _, ok := resolvePullSpec(stable, "cli", true); !ok {
 		return fmt.Errorf("no 'cli' image was tagged into the stable stream, that image is required for building a release")
 	}
 
@@ -147,25 +147,4 @@ func AssembleReleaseStep(config api.ReleaseTagConfiguration, resources api.Resou
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 	}
-}
-
-func resolvePullSpec(is *imageapi.ImageStream, tag string) (string, bool) {
-	for _, tags := range is.Status.Tags {
-		if tags.Tag != tag {
-			continue
-		}
-		if len(tags.Items) == 0 {
-			break
-		}
-		if image := tags.Items[0].Image; len(image) > 0 {
-			if len(is.Status.PublicDockerImageRepository) > 0 {
-				return fmt.Sprintf("%s@%s", is.Status.PublicDockerImageRepository, image), true
-			}
-			if len(is.Status.DockerImageRepository) > 0 {
-				return fmt.Sprintf("%s@%s", is.Status.DockerImageRepository, image), true
-			}
-		}
-		break
-	}
-	return "", false
 }

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -1,4 +1,4 @@
-package steps
+package release
 
 import (
 	"context"

--- a/pkg/steps/write_params.go
+++ b/pkg/steps/write_params.go
@@ -13,7 +13,7 @@ import (
 )
 
 type writeParametersStep struct {
-	params    *DeferredParameters
+	params    *api.DeferredParameters
 	paramFile string
 }
 
@@ -69,7 +69,7 @@ func (s *writeParametersStep) Name() string { return "parameters/write" }
 
 func (s *writeParametersStep) Description() string { return "Write the job parameters to disk" }
 
-func WriteParametersStep(params *DeferredParameters, paramFile string) api.Step {
+func WriteParametersStep(params *api.DeferredParameters, paramFile string) api.Step {
 	return &writeParametersStep{
 		params:    params,
 		paramFile: paramFile,

--- a/pkg/steps/write_params_test.go
+++ b/pkg/steps/write_params_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestWriteParamsStep(t *testing.T) {
-	params := NewDeferredParameters()
+	params := api.NewDeferredParameters()
 	params.Add("K1", someStepLink("another-step"), func() (string, error) { return "V1", nil })
 	params.Add("K2", someStepLink("another-step"), func() (string, error) { return "V:2", nil })
 	paramFile, err := ioutil.TempFile("", "")


### PR DESCRIPTION
This is code movement only in preparation for supporting upgrades
by building an initial release image and a final release image.
By moving all release steps in the same package we reduce the size
of the steps package and keep closely related code together. A
subsequent commit will leverage building release images from within
the tag input release code to get the "initial payload".