### PR TITLE
Add trailing slash to baserepo, some yum-utils complain

### DIFF
--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -14,7 +14,7 @@ import (
 
 func rpmInjectionDockerfile(from api.PipelineImageStreamTagReference, repo string) string {
 	return fmt.Sprintf(`FROM %s:%s
-RUN echo $'[built]\nname = Built RPMs\nbaseurl = http://%s\ngpgcheck = 0\nenabled = 0\n\n[origin-local-release]\nname = Built RPMs\nbaseurl = http://%s\ngpgcheck = 0\nenabled = 0' > /etc/yum.repos.d/built.repo`, api.PipelineImageStream, from, repo, repo)
+RUN echo $'[built]\nname = Built RPMs\nbaseurl = http://%s/\ngpgcheck = 0\nenabled = 0\n\n[origin-local-release]\nname = Built RPMs\nbaseurl = http://%s/\ngpgcheck = 0\nenabled = 0' > /etc/yum.repos.d/built.repo`, api.PipelineImageStream, from, repo, repo)
 }
 
 type rpmImageInjectionStep struct {


### PR DESCRIPTION
```
YumRepo Error: All mirror URLs are not using ftp, http[s] or file.
 Eg. http://rpm-repo-ci-op-zcd25n9t.svc.ci.openshift.org
Cannot find a valid baseurl for repo: origin-local-release
```

When we add `/` to the end it works. I've seen this behavior from
other libcurl based projects.