### PR TITLE
If no refs are provided, we can't build source, omit from graph

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -16,7 +16,7 @@ func (config *ReleaseBuildConfiguration) Validate() error {
 	var validationErrors []error
 
 	validationErrors = append(validationErrors, validateReleaseBuildConfiguration(config)...)
-	validationErrors = append(validationErrors, validateBuildRootImageConfiguration("build_root", config.InputConfiguration.BuildRootImage)...)
+	validationErrors = append(validationErrors, validateBuildRootImageConfiguration("build_root", config.InputConfiguration.BuildRootImage, len(config.Images) > 0)...)
 	validationErrors = append(validationErrors, validateTestStepConfiguration("tests", config.Tests, config.ReleaseTagConfiguration)...)
 
 	if config.InputConfiguration.BaseImages != nil {
@@ -73,9 +73,12 @@ func validatePromotionWithTagSpec(promotion *PromotionConfiguration, tagSpec *Re
 	return validationErrors
 }
 
-func validateBuildRootImageConfiguration(fieldRoot string, input *BuildRootImageConfiguration) []error {
+func validateBuildRootImageConfiguration(fieldRoot string, input *BuildRootImageConfiguration, hasImages bool) []error {
 	if input == nil {
-		return []error{errors.New("'build_root' is required and must have image_stream_tag or project_image")}
+		if hasImages {
+			return []error{errors.New("when 'images' are specified 'build_root' is required and must have image_stream_tag or project_image")}
+		}
+		return nil
 	}
 
 	if input.ProjectImageBuild != nil && input.ImageStreamTagReference != nil {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -308,18 +308,20 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 		}
 	}
 
-	buildSteps = append(buildSteps, api.StepConfiguration{SourceStepConfiguration: &api.SourceStepConfiguration{
-		From:      api.PipelineImageStreamTagReferenceRoot,
-		To:        api.PipelineImageStreamTagReferenceSource,
-		PathAlias: config.CanonicalGoRepository,
-		ClonerefsImage: api.ImageStreamTagReference{
-			Cluster:   "https://api.ci.openshift.org",
-			Namespace: "ci",
-			Name:      "clonerefs",
-			Tag:       "latest",
-		},
-		ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
-	}})
+	if jobSpec.Refs != nil || len(jobSpec.ExtraRefs) > 0 {
+		buildSteps = append(buildSteps, api.StepConfiguration{SourceStepConfiguration: &api.SourceStepConfiguration{
+			From:      api.PipelineImageStreamTagReferenceRoot,
+			To:        api.PipelineImageStreamTagReferenceSource,
+			PathAlias: config.CanonicalGoRepository,
+			ClonerefsImage: api.ImageStreamTagReference{
+				Cluster:   "https://api.ci.openshift.org",
+				Namespace: "ci",
+				Name:      "clonerefs",
+				Tag:       "latest",
+			},
+			ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+		}})
+	}
 
 	if len(config.BinaryBuildCommands) > 0 {
 		buildSteps = append(buildSteps, api.StepConfiguration{PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{


### PR DESCRIPTION
If we get an empty job spec for source from a periodic, we shouldn't
add src to the graph. If the requested targets require src, the
job will fail, but if they don't the graph will continue.

Found while debugging upgrade jobs (that don't need source)