### PR TITLE
RELEASE_IMAGE_INITIAL on a PR is based on stable, not stable-initial

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -160,7 +160,7 @@ func (s *assembleReleaseStep) Run(ctx context.Context, dry bool) error {
 		SkipLogs: true,
 		As:       fmt.Sprintf("release-%s", tag),
 		From: api.ImageStreamTagReference{
-			Name: api.StableImageStream,
+			Name: streamName,
 			Tag:  "cli",
 		},
 		ServiceAccountName: "builder",
@@ -171,7 +171,7 @@ export HOME=/tmp
 oc registry login
 oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q
 oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
-`, s.jobSpec.Namespace, api.StableImageStream, cvo, destination, destination, tag),
+`, s.jobSpec.Namespace, streamName, cvo, destination, destination, tag),
 	}
 
 	// set an explicit default for release-latest resources, but allow customization if necessary
@@ -327,7 +327,7 @@ func (s *assembleReleaseStep) importFromReleaseImage(ctx context.Context, dry bo
 		SkipLogs: true,
 		As:       target,
 		From: api.ImageStreamTagReference{
-			Name: api.StableImageStream,
+			Name: streamName,
 			Tag:  "cli",
 		},
 		ServiceAccountName: "builder",


### PR DESCRIPTION
PR based jobs were creating two release images pointing to stable,
instead of one pointing to stable-initial and one pointing to stable.

Also, we were assuming that stable existed in order to tag in a temp
location cli, but we can't safely do that without taking a dependency
on stable, which initial shouldn't do. So have the extraction code
use stable-initial:cli for calling `oc adm release ...`.