### PR TITLE
Add prepublish raw_step config option to publish images from PRs

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -39,6 +39,12 @@ func (config *ReleaseBuildConfiguration) Validate() error {
 		validationErrors = append(validationErrors, validatePromotionConfiguration("promotion", *config.PromotionConfiguration)...)
 	}
 
+	for i, rawStep := range config.RawSteps {
+		if rawStep.PrePublishOutputImageTagStepConfiguration != nil {
+			validationErrors = append(validationErrors, validatePrepublishConfiguration(fmt.Sprintf("raw_steps[%d]", i), rawStep.PrePublishOutputImageTagStepConfiguration)...)
+		}
+	}
+
 	var lines []string
 	for _, err := range validationErrors {
 		if err == nil {
@@ -281,6 +287,23 @@ func validateReleaseBuildConfiguration(input *ReleaseBuildConfiguration) []error
 	}
 
 	validationErrors = append(validationErrors, validateResources("resources", input.Resources)...)
+	return validationErrors
+}
+
+func validatePrepublishConfiguration(fieldRoot string, input *PrePublishOutputImageTagStepConfiguration) []error {
+	var validationErrors []error
+
+	if len(input.From) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("%s.from: no from image defined", fieldRoot))
+	}
+
+	if len(input.To.Namespace) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("%s.to: no namespace defined", fieldRoot))
+	}
+
+	if len(input.To.Name) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("%s.to: no name defined", fieldRoot))
+	}
 	return validationErrors
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -218,6 +218,16 @@ type PromotionConfiguration struct {
 	AdditionalImages map[string]string `json:"additional_images,omitempty"`
 }
 
+type PrePublishImageTagConfiguration struct {
+	// Namespace identifies the namespace to which the built
+	// artifacts will be published to.
+	Namespace string `json:"namespace"`
+
+	// Name is an optional image stream name to use that
+	// contains all component tags.
+	Name string `json:"name"`
+}
+
 // StepConfiguration holds one step configuration.
 // Only one of the fields in this can be non-null.
 type StepConfiguration struct {
@@ -225,6 +235,7 @@ type StepConfiguration struct {
 	PipelineImageCacheStepConfiguration         *PipelineImageCacheStepConfiguration         `json:"pipeline_image_cache_step,omitempty"`
 	SourceStepConfiguration                     *SourceStepConfiguration                     `json:"source_step,omitempty"`
 	ProjectDirectoryImageBuildStepConfiguration *ProjectDirectoryImageBuildStepConfiguration `json:"project_directory_image_build_step,omitempty"`
+	PrePublishOutputImageTagStepConfiguration   *PrePublishOutputImageTagStepConfiguration   `json:"pre_publish_output_images_step,omitempty"`
 	RPMImageInjectionStepConfiguration          *RPMImageInjectionStepConfiguration          `json:"rpm_image_injection_step,omitempty"`
 	RPMServeStepConfiguration                   *RPMServeStepConfiguration                   `json:"rpm_serve_step,omitempty"`
 	OutputImageTagStepConfiguration             *OutputImageTagStepConfiguration             `json:"output_image_tag_step,omitempty"`
@@ -252,6 +263,13 @@ type OutputImageTagStepConfiguration struct {
 	// promoted unless explicitly targeted. Use for builds which
 	// are invoked only when testing certain parts of the repo.
 	Optional bool `json:"optional"`
+}
+
+// PrePublishOutputImageTagStepConfiguration  describes a step that
+// tags a pipeline image out from the build pipeline per pull-request build.
+type PrePublishOutputImageTagStepConfiguration struct {
+	From PipelineImageStreamTagReference `json:"from"`
+	To   PrePublishImageTagConfiguration `json:"to"`
 }
 
 // PipelineImageCacheStepConfiguration describes a

--- a/pkg/steps/image_stream_util.go
+++ b/pkg/steps/image_stream_util.go
@@ -1,0 +1,96 @@
+package steps
+
+import (
+	"encoding/json"
+	"fmt"
+
+	imageapi "github.com/openshift/api/image/v1"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createImageStreamWithTag(
+	isClient imageclientset.ImageStreamsGetter,
+	istClient imageclientset.ImageStreamTagsGetter,
+	fromNamespace, fromName, fromTag,
+	toNamespace, toName, toTag string,
+	dry bool,
+) error {
+	fromImage := "dry-fake"
+	if !dry {
+		from, err := istClient.ImageStreamTags(fromNamespace).Get(fmt.Sprintf("%s:%s", fromName, fromTag), meta.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("could not resolve base image: %v", err)
+		}
+		fromImage = from.Image.Name
+	}
+
+	is := &imageapi.ImageStream{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      toName,
+			Namespace: toNamespace,
+		},
+	}
+
+	ist := &imageapi.ImageStreamTag{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      fmt.Sprintf("%s:%s", toName, toTag),
+			Namespace: toNamespace,
+		},
+		Tag: &imageapi.TagReference{
+			ReferencePolicy: imageapi.TagReferencePolicy{
+				Type: imageapi.LocalTagReferencePolicy,
+			},
+			From: &coreapi.ObjectReference{
+				Kind:      "ImageStreamImage",
+				Name:      fmt.Sprintf("%s@%s", fromName, fromImage),
+				Namespace: fromNamespace,
+			},
+		},
+	}
+
+	if dry {
+		isJSON, err := json.MarshalIndent(is, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal imagestream: %v", err)
+		}
+		fmt.Printf("%s\n", isJSON)
+
+		istJSON, err := json.MarshalIndent(ist, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
+		}
+		fmt.Printf("%s\n", istJSON)
+		return nil
+	}
+
+	_, err := isClient.ImageStreams(is.Namespace).Get(is.Name, meta.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = isClient.ImageStreams(is.Namespace).Create(is)
+	}
+	if err != nil {
+		return fmt.Errorf("could not retrieve target imagestream: %v", err)
+	}
+
+	if err = istClient.ImageStreamTags(ist.Namespace).Delete(ist.Name, nil); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("could not remove output imagestreamtag: %v", err)
+	}
+	_, err = istClient.ImageStreamTags(ist.Namespace).Create(ist)
+	if err != nil {
+		return fmt.Errorf("could not create output imagestreamtag: %v", err)
+	}
+	return nil
+}
+
+func imagesStreamTagExists(istClient imageclientset.ImageStreamTagsGetter, namespace, name, tag string) (bool, error) {
+	istName := fmt.Sprintf("%s:%s", name, tag)
+	if _, err := istClient.ImageStreamTags(namespace).Get(istName, meta.GetOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not retrieve output imagestreamtag %s: %v", istName, err)
+	}
+	return true, nil
+}

--- a/pkg/steps/pre_publish_images.go
+++ b/pkg/steps/pre_publish_images.go
@@ -1,0 +1,155 @@
+package steps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+
+	imageapi "github.com/openshift/api/image/v1"
+	"github.com/openshift/ci-operator/pkg/api"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PrePublishOutputImageTagStep will ensure that a tag exists
+// in the named ImageStream that resolves to the built
+// pipeline image
+type prePublishOutputImageTagStep struct {
+	config    api.PrePublishOutputImageTagStepConfiguration
+	istClient imageclientset.ImageStreamTagsGetter
+	isClient  imageclientset.ImageStreamsGetter
+	jobSpec   *api.JobSpec
+	tag       string
+}
+
+type prepublishConfig struct {
+	namespace, name, tag string
+}
+
+func (s *prePublishOutputImageTagStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
+	return nil, nil
+}
+
+func (s *prePublishOutputImageTagStep) Run(ctx context.Context, dry bool) error {
+	log.Printf("Tagging %s into %s/%s:%s", s.config.From, s.config.To.Namespace, s.config.To.Name, s.tag)
+
+	fromImage := "dry-fake"
+	if !dry {
+		from, err := s.istClient.ImageStreamTags(s.jobSpec.Namespace).Get(fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From), meta.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("could not resolve base image: %v", err)
+		}
+		fromImage = from.Image.Name
+	}
+
+	is := &imageapi.ImageStream{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      s.config.To.Name,
+			Namespace: s.config.To.Namespace,
+		},
+	}
+
+	ist := &imageapi.ImageStreamTag{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      fmt.Sprintf("%s:%s", s.config.To.Name, s.tag),
+			Namespace: s.config.To.Namespace,
+		},
+		Tag: &imageapi.TagReference{
+			ReferencePolicy: imageapi.TagReferencePolicy{
+				Type: imageapi.LocalTagReferencePolicy,
+			},
+			From: &coreapi.ObjectReference{
+				Kind:      "ImageStreamImage",
+				Name:      fmt.Sprintf("%s@%s", api.PipelineImageStream, fromImage),
+				Namespace: s.jobSpec.Namespace,
+			},
+		},
+	}
+
+	if dry {
+		isJSON, err := json.MarshalIndent(is, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal imagestream: %v", err)
+		}
+		fmt.Printf("%s\n", isJSON)
+
+		istJSON, err := json.MarshalIndent(ist, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
+		}
+		fmt.Printf("%s\n", istJSON)
+		return nil
+	}
+
+	_, err := s.isClient.ImageStreams(is.Namespace).Get(is.Name, meta.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = s.isClient.ImageStreams(is.Namespace).Create(is)
+	}
+	if err != nil {
+		return fmt.Errorf("could not retrieve target imagestream: %v", err)
+	}
+
+	if err = s.istClient.ImageStreamTags(ist.Namespace).Delete(ist.Name, nil); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("could not remove output imagestreamtag: %v", err)
+	}
+	_, err = s.istClient.ImageStreamTags(ist.Namespace).Create(ist)
+	if err != nil {
+		return fmt.Errorf("could not create output imagestreamtag: %v", err)
+	}
+
+	return nil
+}
+
+func (s *prePublishOutputImageTagStep) Done() (bool, error) {
+	log.Printf("Checking for existence of %s/%s:%s", s.config.To.Namespace, s.config.To.Name, s.tag)
+	name := fmt.Sprintf("%s:%s", s.config.To.Name, s.tag)
+	if _, err := s.istClient.ImageStreamTags(s.config.To.Namespace).Get(name, meta.GetOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not retrieve output imagestreamtag %s: %v", name, err)
+	}
+	return true, nil
+}
+
+func (s *prePublishOutputImageTagStep) Requires() []api.StepLink {
+	return []api.StepLink{api.InternalImageLink(s.config.From), api.ReleaseImagesLink()}
+}
+
+func (s *prePublishOutputImageTagStep) Creates() []api.StepLink {
+	ref := api.ImageStreamTagReference{
+		Name:      s.config.To.Name,
+		Tag:       s.tag,
+		Namespace: s.config.To.Namespace,
+	}
+	return []api.StepLink{api.ExternalImageLink(ref)}
+}
+
+func (s *prePublishOutputImageTagStep) Provides() (api.ParameterMap, api.StepLink) {
+	return nil, nil
+}
+
+func (s *prePublishOutputImageTagStep) Name() string {
+	return fmt.Sprintf("[prepublish:%s:%s]", s.config.To.Namespace, s.config.To.Name)
+}
+
+func (s *prePublishOutputImageTagStep) Description() string {
+	return fmt.Sprintf("Tag the image %s into the image stream tag %s/%s:%s", s.config.From, s.config.To.Namespace, s.config.To.Name, s.tag)
+}
+
+func PrePublishOutputImageTagStep(config api.PrePublishOutputImageTagStepConfiguration, istClient imageclientset.ImageStreamTagsGetter, isClient imageclientset.ImageStreamsGetter, jobSpec *api.JobSpec) api.Step {
+	pull := jobSpec.Refs.Pulls[0]
+	pullNumber := strconv.Itoa(pull.Number)
+	tag := "pr-" + pullNumber
+	return &prePublishOutputImageTagStep{
+		config:    config,
+		istClient: istClient,
+		isClient:  isClient,
+		jobSpec:   jobSpec,
+		tag:       tag,
+	}
+}

--- a/pkg/steps/pre_publish_images_test.go
+++ b/pkg/steps/pre_publish_images_test.go
@@ -1,0 +1,115 @@
+package steps
+
+import (
+	"testing"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	"github.com/openshift/ci-operator/pkg/api"
+)
+
+func TestPrePublishOutputImageTagStep(t *testing.T) {
+	config := api.PrePublishOutputImageTagStepConfiguration{
+		From: api.PipelineImageStreamTagReference("some-image"),
+		To: api.PrePublishImageTagConfiguration{
+			Namespace: "configToNamespace",
+			Name:      "configToName",
+		},
+	}
+
+	fakecs := ciopTestingClient{
+		kubecs:  nil,
+		imagecs: fakeimageclientset.NewSimpleClientset(),
+		t:       t,
+	}
+
+	client := fakecs.imagecs.ImageV1()
+
+	is := &imagev1.ImageStream{
+		ObjectMeta: meta.ObjectMeta{Name: config.To.Name},
+		Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "uri://somewhere"},
+	}
+
+	if _, err := client.ImageStreams(config.To.Namespace).Create(is); err != nil {
+		t.Errorf("Could not set up testing ImageStream: %v", err)
+	}
+
+	jobspec := &api.JobSpec{
+		Namespace: "job-namespace",
+		Refs: &api.Refs{
+			Pulls: []api.Pull{
+				{
+					Number: 1234,
+				},
+			},
+		},
+	}
+
+	ist := &imagev1.ImageStreamTag{
+		ObjectMeta: meta.ObjectMeta{Name: "pipeline:some-image"},
+		Image:      imagev1.Image{ObjectMeta: meta.ObjectMeta{Name: "fromImageName"}},
+	}
+
+	if _, err := client.ImageStreamTags(jobspec.Namespace).Create(ist); err != nil {
+		t.Errorf("Could not set up testing ImageStreamTag: %v", err)
+	}
+
+	prePublishStep := PrePublishOutputImageTagStep(config, client, client, jobspec)
+
+	specification := stepExpectation{
+		name: "[prepublish:configToNamespace:configToName]",
+		requires: []api.StepLink{
+			api.InternalImageLink(config.From),
+			api.ReleaseImagesLink(),
+		},
+		creates: []api.StepLink{
+			api.ExternalImageLink(api.ImageStreamTagReference{
+				Name:      "configToName",
+				Tag:       "pr-1234",
+				Namespace: "configToNamespace",
+			}),
+		},
+		provides: providesExpectation{},
+		inputs:   inputsExpectation{values: nil, err: false},
+	}
+
+	execSpecification := executionExpectation{
+		prerun:   doneExpectation{value: false, err: false},
+		runError: false,
+		postrun:  doneExpectation{value: true, err: false},
+	}
+
+	examineStep(t, prePublishStep, specification)
+	executeStep(t, prePublishStep, execSpecification, nil)
+
+	expectedImageStreamTag := &imagev1.ImageStreamTag{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "configToName:pr-1234",
+			Namespace: "configToNamespace",
+		},
+		Tag: &imagev1.TagReference{
+			From: &corev1.ObjectReference{
+				Kind:      "ImageStreamImage",
+				Namespace: "job-namespace",
+				Name:      "pipeline@fromImageName",
+			},
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
+		},
+	}
+
+	targetImageStreamTag, err := client.ImageStreamTags("configToNamespace").Get("configToName:pr-1234", meta.GetOptions{})
+	if err != nil {
+		t.Errorf("Failed to get ImageStreamTag 'configToName:configToTag' after step execution: %v", err)
+	}
+
+	if !equality.Semantic.DeepEqual(expectedImageStreamTag, targetImageStreamTag) {
+		t.Errorf("Different ImageStreamTag 'pipeline:TO' after step execution:\n%s", diff.ObjectReflectDiff(expectedImageStreamTag, targetImageStreamTag))
+	}
+}

--- a/pkg/steps/testing.go
+++ b/pkg/steps/testing.go
@@ -111,6 +111,7 @@ func someStepLink(as string) api.StepLink {
 }
 
 func errorCheck(t *testing.T, message string, expected bool, err error) {
+	t.Helper()
 	if expected && err == nil {
 		t.Errorf("%s: expected to return error, returned nil", message)
 	}
@@ -120,6 +121,7 @@ func errorCheck(t *testing.T, message string, expected bool, err error) {
 }
 
 func examineStep(t *testing.T, step api.Step, expected stepExpectation) {
+	t.Helper()
 	// Test the "informative" methods
 	if name := step.Name(); name != expected.name {
 		t.Errorf("step.Name() mismatch: expected '%s', got '%s'", expected.name, name)
@@ -159,6 +161,7 @@ func examineStep(t *testing.T, step api.Step, expected stepExpectation) {
 }
 
 func executeStep(t *testing.T, step api.Step, expected executionExpectation, fakeClusterBehavior func()) {
+	t.Helper()
 	done, err := step.Done()
 	if !reflect.DeepEqual(expected.prerun.value, done) {
 		t.Errorf("step.Done() before Run() returned %t, expected %t)", done, expected.prerun.value)


### PR DESCRIPTION
Usage:

```
raw_steps:
- pre_publish_output_images_step:
    from: metering-helm-operator
    to:
      tag: metering-helm-operator
      namespace: metering-prerelease
```

This allows for testing of images before they get merged for use in manual testing or QE evaluation of in-progress features.