### PR TITLE
Add prepublish raw_step config option to publish images from PRs

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -39,6 +39,12 @@ func (config *ReleaseBuildConfiguration) Validate() error {
 		validationErrors = append(validationErrors, validatePromotionConfiguration("promotion", *config.PromotionConfiguration)...)
 	}
 
+	for i, rawStep := range config.RawSteps {
+		if rawStep.PrePublishOutputImageTagStepConfiguration != nil {
+			validationErrors = append(validationErrors, validatePrepublishConfiguration(fmt.Sprintf("raw_steps[%d]", i), rawStep.PrePublishOutputImageTagStepConfiguration)...)
+		}
+	}
+
 	var lines []string
 	for _, err := range validationErrors {
 		if err == nil {
@@ -285,6 +291,23 @@ func validateReleaseBuildConfiguration(input *ReleaseBuildConfiguration) []error
 	}
 
 	validationErrors = append(validationErrors, validateResources("resources", input.Resources)...)
+	return validationErrors
+}
+
+func validatePrepublishConfiguration(fieldRoot string, input *PrePublishOutputImageTagStepConfiguration) []error {
+	var validationErrors []error
+
+	if len(input.From) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("%s.from: no from image defined", fieldRoot))
+	}
+
+	if len(input.To.Namespace) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("%s.to: no namespace defined", fieldRoot))
+	}
+
+	if len(input.To.Name) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("%s.to: no name defined", fieldRoot))
+	}
 	return validationErrors
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -60,6 +60,10 @@ type ReleaseBuildConfiguration struct {
 	// If no promotion is defined, it is defaulted from the ReleaseTagConfiguration.
 	PromotionConfiguration *PromotionConfiguration `json:"promotion,omitempty"`
 
+	// PrepublishConfiguration determines if images are pushed for each build
+	// to a namespace besides the build namespace.
+	PrepublishConfiguration *PrepublishConfiguration `json:"prepublish,omitempty"`
+
 	// Resources is a set of resource requests or limits over the
 	// input types. The special name '*' may be used to set default
 	// requests and limits.
@@ -225,6 +229,22 @@ type PromotionConfiguration struct {
 	Disabled bool `json:"disabled,omitempty"`
 }
 
+type PrepublishConfiguration struct {
+	// Namespace identifies the namespace to which the built
+	// artifacts will be published to.
+	Namespace string `json:"namespace"`
+}
+
+type PrePublishImageTagConfiguration struct {
+	// Namespace identifies the namespace to which the built
+	// artifacts will be published to.
+	Namespace string `json:"namespace"`
+
+	// Name is an optional image stream name to use that
+	// contains all component tags.
+	Name string `json:"name"`
+}
+
 // StepConfiguration holds one step configuration.
 // Only one of the fields in this can be non-null.
 type StepConfiguration struct {
@@ -232,6 +252,7 @@ type StepConfiguration struct {
 	PipelineImageCacheStepConfiguration         *PipelineImageCacheStepConfiguration         `json:"pipeline_image_cache_step,omitempty"`
 	SourceStepConfiguration                     *SourceStepConfiguration                     `json:"source_step,omitempty"`
 	ProjectDirectoryImageBuildStepConfiguration *ProjectDirectoryImageBuildStepConfiguration `json:"project_directory_image_build_step,omitempty"`
+	PrePublishOutputImageTagStepConfiguration   *PrePublishOutputImageTagStepConfiguration   `json:"pre_publish_output_images_step,omitempty"`
 	RPMImageInjectionStepConfiguration          *RPMImageInjectionStepConfiguration          `json:"rpm_image_injection_step,omitempty"`
 	RPMServeStepConfiguration                   *RPMServeStepConfiguration                   `json:"rpm_serve_step,omitempty"`
 	OutputImageTagStepConfiguration             *OutputImageTagStepConfiguration             `json:"output_image_tag_step,omitempty"`
@@ -259,6 +280,13 @@ type OutputImageTagStepConfiguration struct {
 	// promoted unless explicitly targeted. Use for builds which
 	// are invoked only when testing certain parts of the repo.
 	Optional bool `json:"optional"`
+}
+
+// PrePublishOutputImageTagStepConfiguration  describes a step that
+// tags a pipeline image out from the build pipeline per pull-request build.
+type PrePublishOutputImageTagStepConfiguration struct {
+	From PipelineImageStreamTagReference `json:"from"`
+	To   PrePublishImageTagConfiguration `json:"to"`
 }
 
 // PipelineImageCacheStepConfiguration describes a

--- a/pkg/steps/image_stream_util.go
+++ b/pkg/steps/image_stream_util.go
@@ -1,0 +1,98 @@
+package steps
+
+import (
+	"encoding/json"
+	"fmt"
+
+	imageapi "github.com/openshift/api/image/v1"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+func createImageStreamWithTag(
+	isClient imageclientset.ImageStreamsGetter,
+	istClient imageclientset.ImageStreamTagsGetter,
+	is *imageapi.ImageStream,
+	ist *imageapi.ImageStreamTag,
+	dry bool,
+) error {
+	if dry {
+		isJSON, err := json.MarshalIndent(is, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal imagestream: %v", err)
+		}
+		fmt.Printf("%s\n", isJSON)
+
+		istJSON, err := json.MarshalIndent(ist, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
+		}
+		fmt.Printf("%s\n", istJSON)
+		return nil
+	}
+
+	_, err := isClient.ImageStreams(is.Namespace).Create(is)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("could not create target imagestream: %v", err)
+	}
+
+	// Create if not exists, update if it does
+	if _, err := istClient.ImageStreamTags(ist.Namespace).Create(ist); err != nil {
+		if errors.IsAlreadyExists(err) {
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				existingIst, err := istClient.ImageStreamTags(ist.Namespace).Get(ist.Name, meta.GetOptions{})
+				if err != nil {
+					return err
+				}
+				// We don't care about the existing imagestreamtag's state, we just
+				// want it to look like the new one, so we only copy the
+				// ResourceVersion so we can update it.
+				ist.ResourceVersion = existingIst.ResourceVersion
+				if _, err = istClient.ImageStreamTags(ist.Namespace).Update(ist); err != nil {
+					return err
+				}
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("could not update output imagestreamtag: %v", err)
+			}
+		} else {
+			return fmt.Errorf("could not create output imagestreamtag: %v", err)
+		}
+	}
+	return nil
+}
+
+func newImageStream(namespace, name string) *imageapi.ImageStream {
+	return &imageapi.ImageStream{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func newImageStreamTag(
+	fromNamespace, fromName, fromTag,
+	toNamespace, toName, toTag string,
+) *imageapi.ImageStreamTag {
+	return &imageapi.ImageStreamTag{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      fmt.Sprintf("%s:%s", toName, toTag),
+			Namespace: toNamespace,
+		},
+		Tag: &imageapi.TagReference{
+			ReferencePolicy: imageapi.TagReferencePolicy{
+				Type: imageapi.LocalTagReferencePolicy,
+			},
+			From: &coreapi.ObjectReference{
+				Kind:      "ImageStreamImage",
+				Name:      fmt.Sprintf("%s@%s", fromName, fromTag),
+				Namespace: fromNamespace,
+			},
+		},
+	}
+}

--- a/pkg/steps/images_ready.go
+++ b/pkg/steps/images_ready.go
@@ -6,40 +6,54 @@ import (
 	"github.com/openshift/ci-operator/pkg/api"
 )
 
-type imagesReadyStep struct {
-	links []api.StepLink
+type imagesReadyLinkStep struct {
+	requires, creates []api.StepLink
+	name, description string
 }
 
-func (s *imagesReadyStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
+func (s *imagesReadyLinkStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
 	return nil, nil
 }
 
-func (s *imagesReadyStep) Run(ctx context.Context, dry bool) error {
+func (s *imagesReadyLinkStep) Run(ctx context.Context, dry bool) error {
 	return nil
 }
 
-func (s *imagesReadyStep) Done() (bool, error) {
+func (s *imagesReadyLinkStep) Done() (bool, error) {
 	return true, nil
 }
 
-func (s *imagesReadyStep) Requires() []api.StepLink {
-	return s.links
+func (s *imagesReadyLinkStep) Requires() []api.StepLink {
+	return s.requires
 }
 
-func (s *imagesReadyStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ImagesReadyLink()}
+func (s *imagesReadyLinkStep) Creates() []api.StepLink {
+	return s.creates
 }
 
-func (s *imagesReadyStep) Provides() (api.ParameterMap, api.StepLink) {
+func (s *imagesReadyLinkStep) Provides() (api.ParameterMap, api.StepLink) {
 	return nil, nil
 }
 
-func (s *imagesReadyStep) Name() string { return "[images]" }
+func (s *imagesReadyLinkStep) Name() string { return s.name }
 
-func (s *imagesReadyStep) Description() string { return "All images are built and tagged into stable" }
+func (s *imagesReadyLinkStep) Description() string {
+	return s.description
+}
 
-func ImagesReadyStep(links []api.StepLink) api.Step {
-	return &imagesReadyStep{
-		links: links,
+func ImagesReadyStep(requires []api.StepLink) api.Step {
+	return newImagesReadyLinkStep(requires, []api.StepLink{api.ImagesReadyLink()}, "[images]", "All images are built and tagged into stable")
+}
+
+func PrepublishImagesReadyStep(requires []api.StepLink) api.Step {
+	return newImagesReadyLinkStep(requires, nil, "[prepublish]", "All images are built and tagged into the prepublish namespace")
+}
+
+func newImagesReadyLinkStep(requires, creates []api.StepLink, name, description string) api.Step {
+	return &imagesReadyLinkStep{
+		requires:    requires,
+		name:        name,
+		creates:     creates,
+		description: description,
 	}
 }

--- a/pkg/steps/images_ready_test.go
+++ b/pkg/steps/images_ready_test.go
@@ -38,3 +38,36 @@ func TestImagesReadyStep(t *testing.T) {
 	examineStep(t, irs, specification)
 	executeStep(t, irs, execSpecification, nil)
 }
+
+func TestPrepublishImagesReadyStep(t *testing.T) {
+	links := []api.StepLink{someStepLink("ONE")}
+	irs := PrepublishImagesReadyStep(links)
+	specification := stepExpectation{
+		name:     "[prepublish]",
+		requires: links,
+		creates:  nil,
+		provides: providesExpectation{
+			params: nil,
+			link:   nil,
+		},
+		inputs: inputsExpectation{
+			values: nil,
+			err:    false,
+		},
+	}
+
+	execSpecification := executionExpectation{
+		prerun: doneExpectation{
+			value: true,
+			err:   false,
+		},
+		runError: false,
+		postrun: doneExpectation{
+			value: true,
+			err:   false,
+		},
+	}
+
+	examineStep(t, irs, specification)
+	executeStep(t, irs, execSpecification, nil)
+}

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -2,7 +2,6 @@ package steps
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -10,11 +9,9 @@ import (
 	imageapi "github.com/openshift/api/image/v1"
 	"github.com/openshift/ci-operator/pkg/api"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
-	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
 )
 
 // outputImageTagStep will ensure that a tag exists
@@ -38,6 +35,7 @@ func (s *outputImageTagStep) Run(ctx context.Context, dry bool) error {
 	} else {
 		log.Printf("Tagging %s into %s/%s:%s", s.config.From, toNamespace, s.config.To.Name, s.config.To.Tag)
 	}
+
 	fromImage := "dry-fake"
 	if !dry {
 		from, err := s.istClient.ImageStreamTags(s.jobSpec.Namespace).Get(fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From), meta.GetOptions{})
@@ -46,41 +44,11 @@ func (s *outputImageTagStep) Run(ctx context.Context, dry bool) error {
 		}
 		fromImage = from.Image.Name
 	}
-	ist := s.imageStreamTag(fromImage)
-	if dry {
-		istJSON, err := json.MarshalIndent(ist, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to marshal imagestreamtag: %v", err)
-		}
-		fmt.Printf("%s\n", istJSON)
-		return nil
-	}
 
-	// Create if not exists, update if it does
-	if _, err := s.istClient.ImageStreamTags(toNamespace).Create(ist); err != nil {
-		if errors.IsAlreadyExists(err) {
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				existingIst, err := s.istClient.ImageStreamTags(ist.Namespace).Get(ist.Name, meta.GetOptions{})
-				if err != nil {
-					return err
-				}
-				// We don't care about the existing imagestreamtag's state, we just
-				// want it to look like the new one, so we only copy the
-				// ResourceVersion so we can update it.
-				ist.ResourceVersion = existingIst.ResourceVersion
-				if _, err = s.istClient.ImageStreamTags(toNamespace).Update(ist); err != nil {
-					return err
-				}
-				return nil
-			})
-			if err != nil {
-				return fmt.Errorf("could not update output imagestreamtag: %v", err)
-			}
-		} else {
-			return fmt.Errorf("could not create output imagestreamtag: %v", err)
-		}
-	}
-	return nil
+	is := newImageStream(s.config.To.Namespace, s.config.To.Name)
+	ist := s.imageStreamTag(fromImage)
+
+	return createImageStreamWithTag(s.isClient, s.istClient, is, ist, dry)
 }
 
 func (s *outputImageTagStep) Done() (bool, error) {
@@ -163,22 +131,10 @@ func (s *outputImageTagStep) namespace() string {
 }
 
 func (s *outputImageTagStep) imageStreamTag(fromImage string) *imageapi.ImageStreamTag {
-	return &imageapi.ImageStreamTag{
-		ObjectMeta: meta.ObjectMeta{
-			Name:      fmt.Sprintf("%s:%s", s.config.To.Name, s.config.To.Tag),
-			Namespace: s.namespace(),
-		},
-		Tag: &imageapi.TagReference{
-			ReferencePolicy: imageapi.TagReferencePolicy{
-				Type: imageapi.LocalTagReferencePolicy,
-			},
-			From: &coreapi.ObjectReference{
-				Kind:      "ImageStreamImage",
-				Name:      fmt.Sprintf("%s@%s", api.PipelineImageStream, fromImage),
-				Namespace: s.jobSpec.Namespace,
-			},
-		},
-	}
+	return newImageStreamTag(
+		s.jobSpec.Namespace, api.PipelineImageStream, fromImage,
+		s.namespace(), s.config.To.Name, s.config.To.Tag,
+	)
 }
 
 func OutputImageTagStep(config api.OutputImageTagStepConfiguration, istClient imageclientset.ImageStreamTagsGetter, isClient imageclientset.ImageStreamsGetter, jobSpec *api.JobSpec) api.Step {

--- a/pkg/steps/pre_publish_images.go
+++ b/pkg/steps/pre_publish_images.go
@@ -1,0 +1,122 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	imageapi "github.com/openshift/api/image/v1"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-operator/pkg/api"
+)
+
+// PrePublishOutputImageTagStep will ensure that a tag exists
+// in the named ImageStream that resolves to the built
+// pipeline image
+type prePublishOutputImageTagStep struct {
+	config    api.PrePublishOutputImageTagStepConfiguration
+	istClient imageclientset.ImageStreamTagsGetter
+	isClient  imageclientset.ImageStreamsGetter
+	jobSpec   *api.JobSpec
+	tag       string
+}
+
+type prepublishConfig struct {
+	namespace, name, tag string
+}
+
+func (s *prePublishOutputImageTagStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
+	return nil, nil
+}
+
+func (s *prePublishOutputImageTagStep) Run(ctx context.Context, dry bool) error {
+	log.Printf("Tagging %s into %s/%s:%s", s.config.From, s.config.To.Namespace, s.config.To.Name, s.tag)
+
+	fromImage := "dry-fake"
+	if !dry {
+		from, err := s.istClient.ImageStreamTags(s.jobSpec.Namespace).Get(fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From), meta.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("could not resolve base image: %v", err)
+		}
+		fromImage = from.Image.Name
+	}
+
+	is := newImageStream(s.config.To.Namespace, s.config.To.Name)
+	ist := s.imageStreamTag(fromImage)
+
+	return createImageStreamWithTag(s.isClient, s.istClient, is, ist, dry)
+}
+
+func (s *prePublishOutputImageTagStep) Done() (bool, error) {
+	log.Printf("Checking for existence of %s/%s:%s", s.config.To.Namespace, s.config.To.Name, s.tag)
+
+	ist, err := s.istClient.ImageStreamTags(s.config.To.Namespace).Get(fmt.Sprintf("%s:%s", s.config.To.Name, s.tag), meta.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not retrieve output imagestreamtag: %v", err)
+	}
+
+	// TODO(chance): this doesn't handle dry run since Done() doesn't have
+	// information about if it's a dry-run
+	from, err := s.istClient.ImageStreamTags(s.jobSpec.Namespace).Get(fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From), meta.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("could not resolve base image: %v", err)
+	}
+
+	desiredIst := s.imageStreamTag(from.Image.Name)
+	// if a tag already exists but doesn't match what we're looking for we're
+	// not done
+	return equality.Semantic.DeepEqual(ist.Tag, desiredIst.Tag), nil
+}
+
+func (s *prePublishOutputImageTagStep) Requires() []api.StepLink {
+	return []api.StepLink{api.InternalImageLink(s.config.From), api.ReleaseImagesLink()}
+}
+
+func (s *prePublishOutputImageTagStep) Creates() []api.StepLink {
+	ref := api.ImageStreamTagReference{
+		Name:      s.config.To.Name,
+		Tag:       s.tag,
+		Namespace: s.config.To.Namespace,
+	}
+	return []api.StepLink{api.ExternalImageLink(ref)}
+}
+
+func (s *prePublishOutputImageTagStep) Provides() (api.ParameterMap, api.StepLink) {
+	return nil, nil
+}
+
+func (s *prePublishOutputImageTagStep) Name() string {
+	return fmt.Sprintf("[prepublish:%s:%s]", s.config.To.Namespace, s.config.To.Name)
+}
+
+func (s *prePublishOutputImageTagStep) Description() string {
+	return fmt.Sprintf("Tag the image %s into the image stream tag %s/%s:%s", s.config.From, s.config.To.Namespace, s.config.To.Name, s.tag)
+}
+
+func (s *prePublishOutputImageTagStep) imageStreamTag(fromImage string) *imageapi.ImageStreamTag {
+	return newImageStreamTag(
+		s.jobSpec.Namespace, api.PipelineImageStream, fromImage,
+		s.config.To.Namespace, s.config.To.Name, s.tag,
+	)
+}
+
+func PrePublishOutputImageTagStep(config api.PrePublishOutputImageTagStepConfiguration, istClient imageclientset.ImageStreamTagsGetter, isClient imageclientset.ImageStreamsGetter, jobSpec *api.JobSpec) api.Step {
+	pull := jobSpec.Refs.Pulls[0]
+	pullNumber := strconv.Itoa(pull.Number)
+	tag := "pr-" + pullNumber
+	return &prePublishOutputImageTagStep{
+		config:    config,
+		istClient: istClient,
+		isClient:  isClient,
+		jobSpec:   jobSpec,
+		tag:       tag,
+	}
+}

--- a/pkg/steps/pre_publish_images_test.go
+++ b/pkg/steps/pre_publish_images_test.go
@@ -1,0 +1,115 @@
+package steps
+
+import (
+	"testing"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	"github.com/openshift/ci-operator/pkg/api"
+)
+
+func TestPrePublishOutputImageTagStep(t *testing.T) {
+	config := api.PrePublishOutputImageTagStepConfiguration{
+		From: api.PipelineImageStreamTagReference("some-image"),
+		To: api.PrePublishImageTagConfiguration{
+			Namespace: "configToNamespace",
+			Name:      "configToName",
+		},
+	}
+
+	fakecs := ciopTestingClient{
+		kubecs:  nil,
+		imagecs: fakeimageclientset.NewSimpleClientset(),
+		t:       t,
+	}
+
+	client := fakecs.imagecs.ImageV1()
+
+	is := &imagev1.ImageStream{
+		ObjectMeta: meta.ObjectMeta{Name: config.To.Name},
+		Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "uri://somewhere"},
+	}
+
+	if _, err := client.ImageStreams(config.To.Namespace).Create(is); err != nil {
+		t.Errorf("Could not set up testing ImageStream: %v", err)
+	}
+
+	jobspec := &api.JobSpec{
+		Namespace: "job-namespace",
+		Refs: &api.Refs{
+			Pulls: []api.Pull{
+				{
+					Number: 1234,
+				},
+			},
+		},
+	}
+
+	ist := &imagev1.ImageStreamTag{
+		ObjectMeta: meta.ObjectMeta{Name: "pipeline:some-image"},
+		Image:      imagev1.Image{ObjectMeta: meta.ObjectMeta{Name: "fromImageName"}},
+	}
+
+	if _, err := client.ImageStreamTags(jobspec.Namespace).Create(ist); err != nil {
+		t.Errorf("Could not set up testing ImageStreamTag: %v", err)
+	}
+
+	prePublishStep := PrePublishOutputImageTagStep(config, client, client, jobspec)
+
+	specification := stepExpectation{
+		name: "[prepublish:configToNamespace:configToName]",
+		requires: []api.StepLink{
+			api.InternalImageLink(config.From),
+			api.ReleaseImagesLink(),
+		},
+		creates: []api.StepLink{
+			api.ExternalImageLink(api.ImageStreamTagReference{
+				Name:      "configToName",
+				Tag:       "pr-1234",
+				Namespace: "configToNamespace",
+			}),
+		},
+		provides: providesExpectation{},
+		inputs:   inputsExpectation{values: nil, err: false},
+	}
+
+	execSpecification := executionExpectation{
+		prerun:   doneExpectation{value: false, err: false},
+		runError: false,
+		postrun:  doneExpectation{value: true, err: false},
+	}
+
+	examineStep(t, prePublishStep, specification)
+	executeStep(t, prePublishStep, execSpecification, nil)
+
+	expectedImageStreamTag := &imagev1.ImageStreamTag{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "configToName:pr-1234",
+			Namespace: "configToNamespace",
+		},
+		Tag: &imagev1.TagReference{
+			From: &corev1.ObjectReference{
+				Kind:      "ImageStreamImage",
+				Namespace: "job-namespace",
+				Name:      "pipeline@fromImageName",
+			},
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
+		},
+	}
+
+	targetImageStreamTag, err := client.ImageStreamTags("configToNamespace").Get("configToName:pr-1234", meta.GetOptions{})
+	if err != nil {
+		t.Errorf("Failed to get ImageStreamTag 'configToName:configToTag' after step execution: %v", err)
+	}
+
+	if !equality.Semantic.DeepEqual(expectedImageStreamTag, targetImageStreamTag) {
+		t.Errorf("Different ImageStreamTag 'pipeline:TO' after step execution:\n%s", diff.ObjectReflectDiff(expectedImageStreamTag, targetImageStreamTag))
+	}
+}


### PR DESCRIPTION
This is the second attempt at PR #301.

The changes to output_image_tag_step in PR #308 make it change easier
to be done by refactoring the original change rather than reverting the
revert at 29e410ae06f2c721de324796b27fffb639ee8d4c.

This step makes it possible to push imagestreamtags built in a
ci-operator job to a specified image stream with a tag named
`$IMAGE_NAME:pr-$PR_NUMBER`

For example:
```
raw_steps:
- pre_publish_output_images_step:
    from: metering-helm-operator
    to:
      name: metering-helm-operator
      namespace: metering-prerelease
- pre_publish_output_images_step:
    from: metering-reporting-operator
    to:
      name: metering-reporting-operator
      namespace: metering-prerelease
```

Will publish imagestreamtags like the following:

```
NAME                                 DOCKER REF                                                                                                                                                 UPDATED
metering-helm-operator:pr-650        docker-registry.default.svc:5000/metering-prerelease/metering-helm-operator@sha256:d111590542171a220ff190b8d9cdf59854528de4545d40cfcf89e3b64ff57ea3        6 days ago
metering-helm-operator:pr-657        docker-registry.default.svc:5000/metering-prerelease/metering-helm-operator@sha256:66e0f0c6b0d5127e1a9794a976f7aae04532ee2eef28a920f234079b68832546        About an hour ago
metering-reporting-operator:pr-650   docker-registry.default.svc:5000/metering-prerelease/metering-reporting-operator@sha256:ae2e0d7df9ec6109e8fe70e42925a47f1d4fe74c6bd0c7c535bf4855e67f247f   6 days ago
```
