### PR TITLE
Make input hash independent on input ordering

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -535,6 +536,7 @@ func (o *options) resolveInputs(ctx context.Context, steps []api.Step) error {
 		glog.V(4).Infof("Could not calculate info from current binary to add to input hash: %v", err)
 	}
 
+	sort.Strings(inputs)
 	o.inputHash = inputHash(inputs)
 
 	// input hash is unique for a given job definition and input refs


### PR DESCRIPTION
The hash function we use is sensitive to ordering of the string slice we
give it as input. It seems we may construct the input slice with
different ordering, so it was possible for ci-operator to place
workloads with identical inputs into different namespaces.

/cc @stevekuznetsov @smarterclayton @droslean @bbguimaraes 