### PR TITLE
Look for likely infrastructure errors in the log snippet

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -245,7 +245,7 @@ func handleBuild(buildClient BuildClient, build *buildapi.Build, dry bool, artif
 				return fmt.Errorf("could not get build %s: %v", build.Name, err)
 			}
 
-			if isInfraReason(b.Status.Reason) {
+			if isInfraReason(b.Status.Reason) || hintsAtInfraReason(b.Status.LogSnippet) {
 				log.Printf("Build %s previously failed from an infrastructure error (%s), retrying...\n", b.Name, b.Status.Reason)
 				zero := int64(0)
 				foreground := meta.DeletePropagationForeground
@@ -312,6 +312,10 @@ func isInfraReason(reason buildapi.StatusReason) bool {
 		}
 	}
 	return false
+}
+
+func hintsAtInfraReason(logSnippet string) bool {
+	return strings.Contains(logSnippet, "error: build error: no such image")
 }
 
 func waitForBuild(buildClient BuildClient, namespace, name string) error {


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Example snippet from one of the recent failed builds:

```
  logSnippet: "--> RUN make build WHAT=cmd/hypershift\nhack/build-go.sh cmd/hypershift
    \n++ Building go targets for linux/amd64: cmd/hypershift\n[INFO] hack/build-go.sh
    exited with code 0 after 00h 00m 48s\nerror: build error: no such image"
```

/assign @smarterclayton 
/cc @openshift/developer-productivity-test-platform 