### PR TITLE
Restore force deletion of tag in outputImageTagStep

### DIFF
--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -54,6 +54,13 @@ func (s *outputImageTagStep) Run(ctx context.Context, dry bool) error {
 		return nil
 	}
 
+	// TODO: this step is "force update" today, but that behavior should be optional in the future
+	//   since other steps are "idempotent". However, the override case supports promotion of machine-os-content
+	//   and will be fixed as part of that.
+	if err := s.istClient.ImageStreamTags(toNamespace).Delete(ist.Name, nil); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("could not remove output imagestreamtag: %v", err)
+	}
+
 	// Create if not exists, if it already exists, then we have nothing to do.
 	if _, err := s.istClient.ImageStreamTags(toNamespace).Create(ist); err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("could not create output imagestreamtag: %v", err)


### PR DESCRIPTION
machine-os-content promotion uses an output_image_tag_step to take
an external dependency and override the stable tag. When we reverted
the update code (for other reasons) the delete case wasn't restored.

Add a TODO that in the future we may want "force" to be a different
step or have optional behavior, since the dominant pattern should be
"if-not-exists".

https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-promote-openshift-machine-os-content-e2e-aws-4.0/106/ was the last passing promotion.  After this, we stopped updating the machine-os-content tag (it already existed), and the revert this morning of the update code meant that the new image wasn't picked up in https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-promote-openshift-machine-os-content-e2e-aws-4.0/114/