### PR TITLE
Importing release images can sometimes fail due to registry errors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,7 @@ Namespace initialization follows input resolution in the `ci-operator` output:
 2018/10/08 05:28:47 Setting up pipeline imagestream for the test
 2018/10/08 05:28:47 Tagging openshift/release:golang-1.10 into pipeline:root
 2018/10/08 05:28:47 Tagging openshift/origin-v4.0:base into pipeline:base
-2018/10/08 05:28:47 Tagged release images from openshift/origin-v4.0:${component}, images will be pullable from registry.svc.ci.openshift.org/ci-op-31xmgx1s/stable:${component}
+2018/10/08 05:28:47 Tagged shared images from openshift/origin-v4.0:${component}, images will be pullable from registry.svc.ci.openshift.org/ci-op-31xmgx1s/stable:${component}
 ```
 
 ## Build Graph Traversal

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -137,12 +137,12 @@ func sourceName(config api.ReleaseTagConfiguration) string {
 
 func (s *releaseImagesTagStep) Run(ctx context.Context, dry bool) error {
 	if dry {
-		log.Printf("Tagging release images from %s", sourceName(s.config))
+		log.Printf("Tagging shared images from %s", sourceName(s.config))
 	} else {
 		if format, err := s.imageFormat(); err == nil {
-			log.Printf("Tagged release images from %s, images will be pullable from %s", sourceName(s.config), format)
+			log.Printf("Tagged shared images from %s, images will be pullable from %s", sourceName(s.config), format)
 		} else {
-			log.Printf("Tagged release images from %s", sourceName(s.config))
+			log.Printf("Tagged shared images from %s", sourceName(s.config))
 		}
 	}
 


### PR DESCRIPTION
Since quay instituted rate limits, we've seen an uptick in flakes. where the upgrade and launch jobs don't get the correct images. In tracking that down it was because the stable image stream is created from the release tag and then we imported the release image contents, but because quay rate limits us we fail to import some of the images. If the user is really unlucky, the installer image will be the one that fails to import, causing the current release tag version (ocp/4.1:installer) to be used instead of the version from the release image (e.g. 4.0.0-0.11).

This prevented the cluster bot from launching 4.0.0-0.11 clusters or running upgrade testing from 4.0.0-0.11 to 4.1.0-rc.0 (because the newer installer image doesn't work with the old payload).

After updating the tags, wait until we see all images imported, and kick the import job (set generation=0) if we observe a failure to import. Also switch to using Local image policy because the cluster will have the image and it prevents us from having to bind the pull secret for quay to the service account of the namespace when we try to run the release payload.

Finally, print out info into the logs about what release is running so we can debug later.