### PR TITLE
When --template is specified, ignore whatever test with that name is defined

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+)
+
+func NodeNames(nodes []*StepNode) []string {
+	var names []string
+	for _, node := range nodes {
+		name := node.Step.Name()
+		if len(name) == 0 {
+			name = fmt.Sprintf("<%T>", node.Step)
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func LinkNames(links []StepLink) []string {
+	var names []string
+	for _, link := range links {
+		name := fmt.Sprintf("<%#v>", link)
+		names = append(names, name)
+	}
+	return names
+}
+
+func TopologicalSort(nodes []*StepNode) ([]*StepNode, error) {
+	var sortedNodes []*StepNode
+	var satisfied []StepLink
+	seen := make(map[Step]struct{})
+	for len(nodes) > 0 {
+		var changed bool
+		var waiting []*StepNode
+		for _, node := range nodes {
+			for _, child := range node.Children {
+				if _, ok := seen[child.Step]; !ok {
+					waiting = append(waiting, child)
+				}
+			}
+			if _, ok := seen[node.Step]; ok {
+				continue
+			}
+			if !HasAllLinks(node.Step.Requires(), satisfied) {
+				waiting = append(waiting, node)
+				continue
+			}
+			satisfied = append(satisfied, node.Step.Creates()...)
+			sortedNodes = append(sortedNodes, node)
+			seen[node.Step] = struct{}{}
+			changed = true
+		}
+		if !changed && len(waiting) > 0 {
+			for _, node := range waiting {
+				var missing []StepLink
+				for _, link := range node.Step.Requires() {
+					if !HasAllLinks([]StepLink{link}, satisfied) {
+						missing = append(missing, link)
+					}
+					log.Printf("step <%T> is missing dependencies: %s", node.Step, strings.Join(LinkNames(missing), ", "))
+				}
+			}
+			return nil, errors.New("steps are missing dependencies")
+		}
+		nodes = waiting
+	}
+	return sortedNodes, nil
+}
+
+func PrintDigraph(w io.Writer, steps []Step) error {
+	for _, step := range steps {
+		for _, other := range steps {
+			if step == other {
+				continue
+			}
+			if HasAnyLinks(step.Requires(), other.Creates()) {
+				if _, err := fmt.Fprintf(w, "%s %s\n", step.Name(), other.Name()); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
As we move templates into the ci-operator, we need a way to stage the
changes for sets of jobs and move gradually. When a user provides
--template on the command line, ignore any job with the same name so that
we can begin moving those to internal definitions.

How would we move jobs over to built in steps:

1. Land this PR to allow templates to override build in steps
2. Identify a set of ProwJobs that can omit the --template parameter that are not generated
3. Update the cluster install e2e step to match the latest template
4. Change the ProwJobs to omit the template parameter
5. Soak for several days
6. Identify any gaps in how we implement the template steps, fix ci-operator (secrets, profiles)
7. Soak more
8. Change ci-operator-prowgen to omit the --template parameter for all generated jobs
9. React and validate