### PR TITLE
Bug 1705243: Two PR jobs can race creating an image stream tag

### DIFF
--- a/test/testdata/copy_input_tag_to_output.yaml
+++ b/test/testdata/copy_input_tag_to_output.yaml
@@ -1,0 +1,53 @@
+# This YAML file demonstrates copying an input tag to an output tag after
+# running a test. It is expected to be run with promote. It is used to gate
+# including an external image into a integration stream for testing before
+# promotion.
+#
+# test with:
+#
+#   JOB_SPEC='{}' ci-operator --config test/testdata/copy_input_tag_to_output.yaml \
+#       --target example --target [output:stable:cli] \
+#       --promote
+#
+# This should:
+# 1. Copy the 4.0 image stream tag into stable:cli
+# 2. Override stable:cli with the 4.1:cli image.
+# 3. If example passes, promote stable:cli (4.1) to test-1/example:cli
+#
+tag_specification:
+  name: "4.0"
+  namespace: ocp
+promotion:
+  name: "example"
+  namespace: test-1
+  additional_images:
+    cli: cli
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.11
+base_images:
+  cli:
+    name: "4.1"
+    namespace: ocp
+    tag: cli
+raw_steps:
+- output_image_tag_step:
+    from: cli
+    to:
+      name: stable
+      tag: cli
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: example
+  commands: which oc
+  container:
+    from: cli


### PR DESCRIPTION
```
2019/05/01 14:42:27 Tagging cli into stable
...
2019/05/01 14:42:33 Ran for 15s
error: could not run steps: step [release:latest] failed: no 'cli' image was tagged into the stable stream, that image is required for building a release
```

If two jobs race, the first creates stable then continues - the second deletes the tag, but then first tries to use the tag and fails.

Replace delete then create with update image stream tag, retry on
conflict, and if it doesn't exist (or another job races with us and
it does exist), ignore that error.

There is a brief window where if the source tag is external the image
import controller might still be importing the image, but most code
in ci-operator now at least checks that condition. If it comes up we
can have output image stream tag loop and wait for import like the
release command does.