### PR TITLE
Report more failures to Sentry

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -163,6 +163,9 @@ func main() {
 	}
 
 	if err := opt.Run(); err != nil {
+		if !opt.dry {
+			opt.reportToSentry(err)
+		}
 		fmt.Printf("error: %v\n", err)
 		opt.writeFailingJUnit(err)
 		os.Exit(1)
@@ -470,7 +473,6 @@ func (o *options) Run() error {
 		}
 		if err != nil {
 			if !o.dry {
-				o.reportToSentry(err)
 				eventRecorder.Event(runtimeObject, coreapi.EventTypeWarning, "CiJobFailed", eventJobDescription(o.jobSpec, o.namespace))
 				time.Sleep(time.Second)
 			}


### PR DESCRIPTION
... by moving it reporting to the outermost layer