### PR TITLE
Make artifacts container survive longer after signal

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -316,7 +316,9 @@ touch /tmp/done
 echo "Waiting for artifacts to be extracted"
 while true; do
 	if [[ ! -f /tmp/done ]]; then
-		echo "Artifacts extracted"
+		echo "Artifacts extracted, will terminate after 30s"
+		sleep 30
+		echo "Exiting"
 		exit 0
 	fi
 	sleep 5 & wait


### PR DESCRIPTION
Artifacts container lives for a while after a first ci-operator instance
manages to fetch the artifacts from it. There may be *other* ci-operator
instance waiting on the pod and fetching artifacts, though, so let them
have more time to finish their artifact grab.

This is not a proper fix of the race, just a bandaid to reduce
occurrences in production. I can watch if the bandaid has a desired effect
in [Sentry](https://sentry.io/organizations/red-hat/issues/1024995691/?project=1456253)

See: https://bugzilla.redhat.com/show_bug.cgi?id=1693865#c12