### PR TITLE
Allow the upgrade template to accept options as env

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -167,6 +167,7 @@ objects:
 
         function run-upgrade-tests() {
           openshift-tests run-upgrade "${TEST_SUITE}" --to-image "${RELEASE_IMAGE_LATEST}" \
+            --options "${TEST_OPTIONS:-}" \
             --provider "${TEST_PROVIDER:-}" -o /tmp/artifacts/e2e.log --junit-dir /tmp/artifacts/junit
           exit 0
         }


### PR DESCRIPTION
In order to perform disruptive upgrade tests, the commands for
a job need to be able to set TEST_OPTIONS to the arg on openshift-tests.

The rollback test will pass `abort-at=random` and the disruptive test will
trigger master reboots periodically.