### PR TITLE
Add OWNERS for built-in templates

### DIFF
--- a/pkg/steps/clusterinstall/OWNERS
+++ b/pkg/steps/clusterinstall/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+  - aaronlevy
+  - abhinavdahiya
+  - crawford
+  - rajatchopra
+  - smarterclayton
+  - staebler
+  - wking
+reviewers:
+  - vikramsk


### PR DESCRIPTION
Took [1] and unrolled `installer-*` groups from [2].

Suggested by @smarterclayton in https://github.com/openshift/ci-operator/pull/349/#issuecomment-493701828

/cc @smarterclayton @stevekuznetsov @bbguimaraes @droslean @hongkailiu 
[1] https://github.com/openshift/release/blob/master/ci-operator/templates/openshift/installer/OWNERS
[2] https://github.com/openshift/release/blob/master/OWNERS_ALIASES