### PR TITLE
*: add azure4 as a known cluster profile

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -373,6 +373,7 @@ field is only valid in tests that provision a cluster (`openshift_ansible`,
 - `aws`
 - `aws-atomic`
 - `aws-centos`
+- `azure4`
 - `gcp`
 - `gcp-ha`
 - `gcp-crio`

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -180,7 +180,7 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 
 func validateClusterProfile(fieldRoot string, p ClusterProfile) []error {
 	switch p {
-	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileOpenStack, ClusterProfileVSphere:
+	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileAzure4, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileOpenStack, ClusterProfileVSphere:
 		return nil
 	}
 	return []error{fmt.Errorf("%q: invalid cluster profile %q", fieldRoot, p)}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -346,6 +346,7 @@ const (
 	ClusterProfileAWSCentos                         = "aws-centos"
 	ClusterProfileAWSCentos40                       = "aws-centos-40"
 	ClusterProfileAWSGluster                        = "aws-gluster"
+	ClusterProfileAzure4                            = "azure4"
 	ClusterProfileGCP                               = "gcp"
 	ClusterProfileGCP40                             = "gcp-40"
 	ClusterProfileGCPHA                             = "gcp-ha"


### PR DESCRIPTION
Adds `azure4` as a known cluster profile. This will be the profile used for OpenShift 4 azure testing.