### PR TITLE
Sentry: Make fingerprints from sanitized error messages

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -955,6 +955,8 @@ func (o *options) reportToSentry(toReport error) {
 	sc := sentry.NewClient(sentry.DSN(dsn))
 
 	sentryOpts := sentryOptionsFromJobSpec(o.jobSpec)
+	fingerprint := makeFingerprint(toReport)
+	sentryOpts = append(sentryOpts, sentry.Fingerprint(fingerprint...))
 	sentryOpts = append(sentryOpts, sentry.Message(toReport.Error()))
 	qEvent := sc.Capture(sentryOpts...)
 
@@ -968,6 +970,60 @@ func (o *options) reportToSentry(toReport error) {
 	case <-time.After(5 * time.Second):
 		log.Printf("Failed to submit failure event to Sentry before 5s timeout")
 	}
+}
+
+func makeFingerprint(toReport error) []string {
+	sanitized := sanitizeMessage(toReport.Error())
+	return []string{sanitized}
+}
+
+type cleanup struct {
+	replacement string
+	patterns    []*regexp.Regexp
+}
+
+func newCleanup(placeholder string, patterns ...string) *cleanup {
+	c := cleanup{replacement: placeholder}
+	for _, pattern := range patterns {
+		c.patterns = append(c.patterns, regexp.MustCompile(pattern))
+	}
+	return &c
+}
+
+func (p *cleanup) apply(message string) string {
+	for _, pattern := range p.patterns {
+		message = pattern.ReplaceAllString(message, p.replacement)
+	}
+	return message
+}
+
+func sanitizeMessage(message string) string {
+	podNames := newCleanup("<PODNAME>", `ci-op-[a-z0-9]{8}`) // ci-op-h4shh4sh
+	isoTimes := newCleanup(
+		"<ISO-DATETIME>",
+		`[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?`, // 2019-05-21T10:12:14Z | 2019-05-21
+	)
+	// Few notes about why this is so complex:
+	// 1. We sometimes want to remove generic items like '4s' (four seconds) that
+	//    can occur also as a word substring (e.g. in hashes). So we rectify this
+	//    by capturing these only if surrounded by non-alpha characters (prefix
+	//    and suffix).
+	// 2. Patterns are searched and replaced in the order in which they are passed
+	//    to the `newCleanup` method (so ordering matters!). This allows to first
+	//    find and replace a whole '00h 24m 26s' duration before we would find
+	//    and replace its '26s' member.
+	durations := newCleanup("${prefix}<DURATION>${suffix}",
+		`(?P<prefix>[[:^alpha:]])([\d]+h )?[\d]+m [\d]+s(?P<suffix>[[:^alpha:]])`, // 2h 4m 2s | 4m 2s
+		`(?P<prefix>[[:^alpha:]])([\d]+\.)?[\d]+ms(?P<suffix>[[:^alpha:]])`,       // 0.24ms | 520ms
+		`(?P<prefix>[[:^alpha:]])([\d]+h)?[\d]+m[\d]+s(?P<suffix>[[:^alpha:]])`,   // 2m24s | 24h12m24s
+		`(?P<prefix>[[:^alpha:]])([\d]+\.)?[\d]+s(?P<suffix>[[:^alpha:]])`,        // 0.24s | 234s
+	)
+
+	for _, rule := range []*cleanup{podNames, isoTimes, durations} {
+		message = rule.apply(message)
+	}
+
+	return message
 }
 
 // eventJobDescription returns a string representing the pull requests and authors description, to be used in events.

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+func TestSanitizeMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{{
+		name:     "pod name",
+		message:  "...pod ci-op-4fg72pn0/unit...",
+		expected: "...pod <PODNAME>/unit...",
+	}, {
+		name:     "ci-operator duration seconds",
+		message:  "...after 39s (failed...",
+		expected: "...after <DURATION> (failed...",
+	}, {
+		name:     "seconds-like pattern not replaced inside words",
+		message:  "some hash is 'h4sh'",
+		expected: "some hash is 'h4sh'",
+	}, {
+		name:     "ci-operator duration minutes",
+		message:  "...after 1m39s (failed...",
+		expected: "...after <DURATION> (failed...",
+	}, {
+		name:     "ci-operator duration hours",
+		message:  "...after 69h1m39s (failed...",
+		expected: "...after <DURATION> (failed...",
+	}, {
+		name:     "seconds duration",
+		message:  "...PASS: TestRegistryProviderGet (2.83s)...",
+		expected: "...PASS: TestRegistryProviderGet (<DURATION>)...",
+	}, {
+		name:     "ms duration",
+		message:  "...PASS: TestRegistryProviderGet 510ms...",
+		expected: "...PASS: TestRegistryProviderGet <DURATION>...",
+	}, {
+		name:     "spaced duration",
+		message:  "...exited with code 1 after 00h 17m 40s...",
+		expected: "...exited with code 1 after <DURATION>...",
+	}, {
+		name:     "ISO time",
+		message:  "...time=\"2019-05-21T15:31:35Z\"...",
+		expected: "...time=\"<ISO-DATETIME>\"...",
+	}, {
+		name:     "ISO DATE",
+		message:  "...date=\"2019-05-21\"...",
+		expected: "...date=\"<ISO-DATETIME>\"...",
+	},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeMessage(tc.message); got != tc.expected {
+				t.Errorf("sanitizeMessage('%s') = '%s', expected '%s'", tc.message, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sanitize error messages from the following disrupting patterns and use
this as an event fingerprint so the events better group together.

- known ci-operator namespace names (containing hashes)
- various durations
- few forms of ISO 8601 dates/times

/cc @bbguimaraes @droslean @stevekuznetsov @hongkailiu 