### PR TITLE
Merge Makefile with ci-operator-prowgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,23 @@
+all: check lint test build
 .PHONY: all
-all: check test build
 
-.PHONY: check
-check: ## Lint code
+build:
+	go build ./cmd/...
+.PHONY: build
+
+install:
+	go install ./cmd/...
+.PHONY: install
+
+test:
+	go test ./...
+.PHONY: test
+
+check lint:
 	gofmt -s -l $(shell go list -f '{{ .Dir }}' ./... ) | grep ".*\.go"; if [ "$$?" = "0" ]; then gofmt -s -d $(shell go list -f '{{ .Dir }}' ./... ); exit 1; fi
-	go vet ./cmd/... ./pkg/...
+	go vet ./...
+.PHONY: check lint
 
 format:
 	gofmt -s -w $(shell go list -f '{{ .Dir }}' ./... )
 .PHONY: format
-
-.PHONY: build
-build: ## Build binary
-	go build -v -o ci-operator ./cmd/ci-operator
-	go build -v -o ci-operator-checkconfig ./cmd/ci-operator-checkconfig
-
-.PHONY: install
-install: ## Install binary
-	go install ./cmd/ci-operator
-	go install ./cmd/ci-operator-checkconfig
-
-.PHONY: test
-test: ## Run tests
-	go test ./...
-
-.PHONY: help
-help:
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
To facilitate merging the repositories, make the Makefiles as similar as
possible.  The redundant `check` and `lint` targets are there to avoid
breaking the CI jobs during the transition and will be removed later.