### PR TITLE
template: extend timeout in waitForPodDeletion

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -422,7 +422,7 @@ func createOrRestartPod(podClient coreclientset.PodInterface, pod *coreapi.Pod) 
 }
 
 func waitForPodDeletion(podClient coreclientset.PodInterface, name string, uid types.UID) error {
-	timeout := 300
+	timeout := 600
 	for i := 0; i < timeout; i += 2 {
 		pod, err := podClient.Get(name, meta.GetOptions{})
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
ci-operator should wait for 10 mins for pod to be deleted, as teradown 
in e2e-aws takes about 7 mins to complete on average

See discussion in #353